### PR TITLE
feat: farewell letters + hexagonal architecture refactor

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -22,21 +22,15 @@ import (
 )
 
 func main() {
-	// Parse CLI flags
 	encryptionKeyFile := flag.String("encryption-key-file", "", "Path to file containing encryption key (fallback, must have 0600 permissions)")
 	flag.Parse()
 
-	// Initialize logging first
 	logging.Init()
 
-	// Initialize encryption key manager (CRITICAL - must happen before any encryption operations)
 	services.InitKeyManager(*encryptionKeyFile)
 
-	// Validate encryption key is available (fail fast if not)
-	// The InitKeyManager already tries to load the key, so we just need to verify it worked
-	// by attempting to use the crypto service
-	cryptoService := services.CryptoService{}
-	_, err := cryptoService.Encrypt("test")
+	cryptoSvc := services.CryptoService{}
+	_, err := cryptoSvc.Encrypt("test")
 	if err != nil {
 		log.Fatalf("FATAL: Failed to initialize encryption key: %v\n\n"+
 			"Please configure one of the following:\n"+
@@ -52,15 +46,24 @@ func main() {
 		if os.Getenv("ALLOWED_ORIGINS") == "" {
 			log.Fatal("ALLOWED_ORIGINS must be set in production")
 		}
-		// Allow * only in simple mode (HTTP-only, IP-based access)
 		if os.Getenv("ALLOWED_ORIGINS") == "*" && os.Getenv("PROXY_MODE") != "simple" {
 			log.Fatal("ALLOWED_ORIGINS cannot be '*' in production (unless using simple mode)")
 		}
 	}
-	// Initialize Database
+
 	database.Connect()
 
-	if err := database.DB.AutoMigrate(&models.User{}, &models.Message{}, &models.MessageReminder{}, &models.Settings{}, &models.Webhook{}, &models.Attachment{}, &models.ApplicationSettings{}); err != nil {
+	if err := database.DB.AutoMigrate(
+		&models.User{},
+		&models.Message{},
+		&models.MessageReminder{},
+		&models.Settings{},
+		&models.Webhook{},
+		&models.Attachment{},
+		&models.ApplicationSettings{},
+		&models.FarewellLetter{},
+		&models.FarewellAttachment{},
+	); err != nil {
 		log.Fatal("Failed to migrate database: ", err)
 	}
 
@@ -72,11 +75,8 @@ func main() {
 		log.Fatal("Failed to ensure application settings: ", err)
 	}
 
-	// Ensure key_fragment has default value for existing records
 	database.DB.Exec("UPDATE messages SET key_fragment = 'local' WHERE key_fragment IS NULL OR key_fragment = '';")
 
-	// Ensure management_token is set for existing records (BeforeCreate hook handles new ones)
-	// For SQLite, we need to update in Go since SQLite doesn't have uuid generation
 	var messagesWithoutToken []models.Message
 	database.DB.Where("management_token IS NULL OR management_token = ''").Find(&messagesWithoutToken)
 	for i := range messagesWithoutToken {
@@ -84,28 +84,44 @@ func main() {
 		database.DB.Save(&messagesWithoutToken[i])
 	}
 
-	// Ensure encrypted_content is not null for existing records
 	database.DB.Exec("UPDATE messages SET encrypted_content = '' WHERE encrypted_content IS NULL;")
-
-	// Ensure webhook_enabled has default value
 	database.DB.Exec("UPDATE settings SET webhook_enabled = 0 WHERE webhook_enabled IS NULL;")
 
-	// Create uploads directory
 	if err := services.EnsureUploadsDir(); err != nil {
 		log.Fatal("Failed to create uploads directory: ", err)
 	}
 
+	// --- Composition root: wire services ---
+	authSvc := services.AuthService{}
+	messageSvc := services.MessageService{}
+	fileSvc := services.FileService{}
+	farewellSvc := services.FarewellService{}
+	settingsSvc := services.SettingsService{}
+	appSettingsSvc := services.ApplicationSettingsService{}
+	webhookStore := services.WebhookStore{}
+	userAdminSvc := services.UserAdminService{}
+
+	// --- Wire handlers ---
+	authH := handlers.NewAuthHandlers(authSvc)
+	messageH := handlers.NewMessageHandlers(messageSvc)
+	heartbeatH := handlers.NewHeartbeatHandlers(messageSvc, settingsSvc)
+	attachH := handlers.NewAttachmentHandlers(fileSvc)
+	settingsH := handlers.NewSettingsHandlers(settingsSvc, appSettingsSvc)
+	webhookH := handlers.NewWebhookHandlers(webhookStore)
+	farewellH := handlers.NewFarewellHandlers(farewellSvc, fileSvc)
+	usersH := handlers.NewUserHandlers(userAdminSvc)
+
+	// --- Wire worker ---
+	w := worker.New(settingsSvc, webhookStore, fileSvc)
+
 	app := fiber.New(fiber.Config{
-		BodyLimit: 12 * 1024 * 1024, // 12MB limit for file uploads
+		BodyLimit: 25 * 1024 * 1024,
 	})
 
-	// Middleware
 	app.Use(requestid.New())
 	app.Use(logger.New(logger.Config{
 		Format: "{\"time\":\"${time}\",\"ip\":\"${ip}\",\"status\":${status},\"method\":\"${method}\",\"path\":\"${path}\",\"latency\":\"${latency}\",\"req_id\":\"${locals:requestid}\"}\n",
 	}))
-
-	// Security headers middleware
 	app.Use(middleware.SecurityHeaders)
 
 	allowedOrigins := os.Getenv("ALLOWED_ORIGINS")
@@ -113,12 +129,9 @@ func main() {
 		allowedOrigins = "http://localhost:5173"
 	}
 
-	// For simple mode (ALLOWED_ORIGINS=*), use dynamic origin to avoid Fiber CORS panic
 	if allowedOrigins == "*" {
 		app.Use(cors.New(cors.Config{
-			AllowOriginsFunc: func(origin string) bool {
-				return true // Allow all origins in simple mode
-			},
+			AllowOriginsFunc: func(origin string) bool { return true },
 			AllowHeaders:     "Origin, Content-Type, Accept",
 			AllowMethods:     "GET, POST, PUT, DELETE, OPTIONS",
 			AllowCredentials: true,
@@ -131,6 +144,7 @@ func main() {
 			AllowCredentials: true,
 		}))
 	}
+
 	app.Use(limiter.New(limiter.Config{
 		Max:        120,
 		Expiration: 1 * time.Minute,
@@ -142,58 +156,58 @@ func main() {
 		},
 	}))
 
-	// Note: CSRF Protection is provided by SameSite=Lax cookies
-	// Additional CSRF token middleware removed as frontend doesn't support it
-	// and SameSite provides sufficient protection for same-site origins
+	// Note: CSRF protection is provided by SameSite=Strict cookies.
+	// SameSite=Strict is stronger than Lax and prevents CSRF for same-site origins.
 
-	// Routes
 	api := app.Group("/api")
 
-	// Public Reveal
-	api.Get("/messages/:id", handlers.GetMessage)
-	api.Get("/setup/status", handlers.SetupStatus)
-	api.Post("/setup", handlers.SetupMasterPassword)
-	api.Post("/auth/register", middleware.AuthRateLimiter, handlers.Register)
-	api.Post("/auth/login", middleware.AuthRateLimiter, handlers.Login)
+	// Public routes
+	api.Get("/messages/:id", messageH.GetPublic)
+	api.Get("/setup/status", authH.SetupStatus)
+	api.Post("/setup", authH.SetupMasterPassword)
+	api.Post("/auth/register", middleware.AuthRateLimiter, authH.Register)
+	api.Post("/auth/login", middleware.AuthRateLimiter, authH.Login)
+	api.Post("/auth/verify", middleware.AuthRateLimiter, authH.VerifyMasterPassword)
+	api.Post("/auth/reset-password", middleware.AuthRateLimiter, authH.ResetMasterPassword)
+	api.Get("/auth/session", authH.SessionStatus)
+	api.Post("/auth/logout", authH.Logout)
+	api.Get("/quick-heartbeat/:token", heartbeatH.QuickHeartbeat)
+	api.Post("/quick-heartbeat/:token", heartbeatH.QuickHeartbeat)
 
-	// Auth endpoints with brute-force protection
-	api.Post("/auth/verify", middleware.AuthRateLimiter, handlers.VerifyMasterPassword)
-	api.Post("/auth/reset-password", middleware.AuthRateLimiter, handlers.ResetMasterPassword)
-	api.Get("/auth/session", handlers.SessionStatus)
-	api.Post("/auth/logout", handlers.Logout)
-
-	// Quick heartbeat (no auth, token-based)
-	// GET: Shows page with button, POST: Triggers heartbeat
-	api.Get("/quick-heartbeat/:token", handlers.QuickHeartbeat)
-	api.Post("/quick-heartbeat/:token", handlers.QuickHeartbeat)
-
-	// Protected Management
+	// Protected routes
 	mgmt := api.Group("/", middleware.MasterAuth)
-	mgmt.Post("/messages", handlers.CreateMessage)
-	mgmt.Get("/messages", handlers.ListMessages)
-	mgmt.Delete("/messages/:id", handlers.DeleteMessage)
-	mgmt.Put("/messages/:id", handlers.UpdateMessage)
-	mgmt.Post("/heartbeat", handlers.Heartbeat)
-	mgmt.Post("/messages/:id/attachments", handlers.UploadAttachment)
-	mgmt.Get("/messages/:id/attachments", handlers.ListAttachments)
-	mgmt.Delete("/messages/:id/attachments/:attachmentId", handlers.DeleteAttachment)
-	mgmt.Get("/webhooks", handlers.ListWebhooks)
-	mgmt.Post("/webhooks", handlers.CreateWebhook)
-	mgmt.Put("/webhooks/:id", handlers.UpdateWebhook)
-	mgmt.Delete("/webhooks/:id", handlers.DeleteWebhook)
+	mgmt.Post("/messages", messageH.Create)
+	mgmt.Get("/messages", messageH.List)
+	mgmt.Delete("/messages/:id", messageH.Delete)
+	mgmt.Put("/messages/:id", messageH.Update)
+	mgmt.Post("/heartbeat", messageH.Heartbeat)
 
-	// Settings
-	mgmt.Get("/settings", handlers.GetSettings)
-	mgmt.Post("/settings", handlers.SaveSettings)
-	mgmt.Post("/settings/test", handlers.TestSMTP)
-	mgmt.Get("/heartbeat-token", handlers.GetHeartbeatToken)
+	mgmt.Post("/messages/:id/attachments", attachH.Upload)
+	mgmt.Get("/messages/:id/attachments", attachH.List)
+	mgmt.Delete("/messages/:id/attachments/:attachmentId", attachH.Delete)
 
-	// User accounts (primary administrator only; enforced in handlers/services)
-	mgmt.Get("/users", handlers.ListUsers)
-	mgmt.Delete("/users/:id", handlers.DeleteUser)
+	mgmt.Get("/messages/:id/farewell-letters", farewellH.List)
+	mgmt.Post("/messages/:id/farewell-letters", farewellH.Create)
+	mgmt.Put("/messages/:id/farewell-letters/:letterId", farewellH.Update)
+	mgmt.Delete("/messages/:id/farewell-letters/:letterId", farewellH.Delete)
+	mgmt.Post("/messages/:id/farewell-letters/:letterId/attachments", farewellH.UploadAttachment)
+	mgmt.Get("/messages/:id/farewell-letters/:letterId/attachments", farewellH.ListAttachments)
+	mgmt.Delete("/messages/:id/farewell-letters/:letterId/attachments/:attachmentId", farewellH.DeleteAttachment)
 
-	// Start Background Worker
-	go worker.Start()
+	mgmt.Get("/webhooks", webhookH.List)
+	mgmt.Post("/webhooks", webhookH.Create)
+	mgmt.Put("/webhooks/:id", webhookH.Update)
+	mgmt.Delete("/webhooks/:id", webhookH.Delete)
+
+	mgmt.Get("/settings", settingsH.Get)
+	mgmt.Post("/settings", settingsH.Save)
+	mgmt.Post("/settings/test", settingsH.TestSMTP)
+	mgmt.Get("/heartbeat-token", heartbeatH.GetToken)
+
+	mgmt.Get("/users", usersH.List)
+	mgmt.Delete("/users/:id", usersH.Delete)
+
+	go w.Start()
 
 	log.Fatal(app.Listen(":3000"))
 }

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/clipperhouse/stringish v0.1.1 // indirect
 	github.com/clipperhouse/uax29/v2 v2.5.0 // indirect
+	github.com/gomarkdown/markdown v0.0.0-20260417124207-7d523f7318df // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/klauspost/compress v1.18.3 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -6,6 +6,8 @@ github.com/clipperhouse/uax29/v2 v2.5.0 h1:x7T0T4eTHDONxFJsL94uKNKPHrclyFI0lm7+w
 github.com/clipperhouse/uax29/v2 v2.5.0/go.mod h1:Wn1g7MK6OoeDT0vL+Q0SQLDz/KpfsVRgg6W7ihQeh4g=
 github.com/gofiber/fiber/v2 v2.52.12 h1:0LdToKclcPOj8PktUdIKo9BUohjjwfnQl42Dhw8/WUw=
 github.com/gofiber/fiber/v2 v2.52.12/go.mod h1:YEcBbO/FB+5M1IZNBP9FO3J9281zgPAreiI1oqg8nDw=
+github.com/gomarkdown/markdown v0.0.0-20260417124207-7d523f7318df h1:Mwihr/o+v4L5h56rwHLOE20+hh7Okhwno5BHz3zDuao=
+github.com/gomarkdown/markdown v0.0.0-20260417124207-7d523f7318df/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=

--- a/backend/internal/handlers/attachment.go
+++ b/backend/internal/handlers/attachment.go
@@ -3,13 +3,21 @@ package handlers
 import (
 	"io"
 
+	"github.com/alpyxn/aeterna/backend/internal/ports"
 	"github.com/alpyxn/aeterna/backend/internal/services"
 	"github.com/gofiber/fiber/v2"
 )
 
-var fileService = services.FileService{}
+// AttachmentHandlers groups switch attachment route handlers.
+type AttachmentHandlers struct {
+	files ports.FileServicePort
+}
 
-func UploadAttachment(c *fiber.Ctx) error {
+func NewAttachmentHandlers(files ports.FileServicePort) *AttachmentHandlers {
+	return &AttachmentHandlers{files: files}
+}
+
+func (h *AttachmentHandlers) Upload(c *fiber.Ctx) error {
 	userID, err := currentUserID(c)
 	if err != nil {
 		return writeError(c, err)
@@ -37,7 +45,7 @@ func UploadAttachment(c *fiber.Ctx) error {
 		mimeType = "application/octet-stream"
 	}
 
-	attachment, err := fileService.Upload(userID, messageID, fileHeader.Filename, mimeType, data)
+	attachment, err := h.files.Upload(userID, messageID, fileHeader.Filename, mimeType, data)
 	if err != nil {
 		return writeError(c, err)
 	}
@@ -48,14 +56,14 @@ func UploadAttachment(c *fiber.Ctx) error {
 	})
 }
 
-func ListAttachments(c *fiber.Ctx) error {
+func (h *AttachmentHandlers) List(c *fiber.Ctx) error {
 	userID, err := currentUserID(c)
 	if err != nil {
 		return writeError(c, err)
 	}
 	messageID := c.Params("id")
 
-	attachments, err := fileService.ListByMessageID(userID, messageID)
+	attachments, err := h.files.ListByMessageID(userID, messageID)
 	if err != nil {
 		return writeError(c, err)
 	}
@@ -63,14 +71,14 @@ func ListAttachments(c *fiber.Ctx) error {
 	return c.JSON(attachments)
 }
 
-func DeleteAttachment(c *fiber.Ctx) error {
+func (h *AttachmentHandlers) Delete(c *fiber.Ctx) error {
 	userID, err := currentUserID(c)
 	if err != nil {
 		return writeError(c, err)
 	}
 	attachmentID := c.Params("attachmentId")
 
-	if err := fileService.Delete(userID, attachmentID); err != nil {
+	if err := h.files.Delete(userID, attachmentID); err != nil {
 		return writeError(c, err)
 	}
 

--- a/backend/internal/handlers/auth.go
+++ b/backend/internal/handlers/auth.go
@@ -5,15 +5,15 @@ import (
 	"time"
 
 	"github.com/alpyxn/aeterna/backend/internal/middleware"
-	"github.com/alpyxn/aeterna/backend/internal/models"
+	"github.com/alpyxn/aeterna/backend/internal/ports"
 	"github.com/alpyxn/aeterna/backend/internal/services"
 	"github.com/gofiber/fiber/v2"
 )
 
 type registerRequest struct {
-	Email       string `json:"email"`
-	Password    string `json:"password"`
-	OwnerEmail  string `json:"owner_email"`
+	Email      string `json:"email"`
+	Password   string `json:"password"`
+	OwnerEmail string `json:"owner_email"`
 }
 
 type loginRequest struct {
@@ -21,16 +21,23 @@ type loginRequest struct {
 	Password string `json:"password"`
 }
 
-var authService = services.AuthService{}
+// AuthHandlers groups all authentication-related route handlers.
+type AuthHandlers struct {
+	auth ports.AuthServicePort
+}
 
-func SetupStatus(c *fiber.Ctx) error {
-	configured, err := authService.IsConfigured()
+func NewAuthHandlers(auth ports.AuthServicePort) *AuthHandlers {
+	return &AuthHandlers{auth: auth}
+}
+
+func (h *AuthHandlers) SetupStatus(c *fiber.Ctx) error {
+	configured, err := h.auth.IsConfigured()
 	if err != nil {
 		return writeError(c, err)
 	}
 	out := fiber.Map{"configured": configured}
 	if configured {
-		allow, err := authService.AdditionalRegistrationOpen()
+		allow, err := h.auth.AdditionalRegistrationOpen()
 		if err != nil {
 			return writeError(c, err)
 		}
@@ -41,9 +48,8 @@ func SetupStatus(c *fiber.Ctx) error {
 	return c.JSON(out)
 }
 
-// SetupMasterPassword is the initial install: creates the first user (same as Register when no users exist).
-func SetupMasterPassword(c *fiber.Ctx) error {
-	configured, err := authService.IsConfigured()
+func (h *AuthHandlers) SetupMasterPassword(c *fiber.Ctx) error {
+	configured, err := h.auth.IsConfigured()
 	if err != nil {
 		return writeError(c, err)
 	}
@@ -56,65 +62,67 @@ func SetupMasterPassword(c *fiber.Ctx) error {
 		return writeError(c, services.BadRequest("Invalid request body", err))
 	}
 	if req.Email == "" && req.Password != "" {
-		// Backward compatibility: old clients sent only password + owner_email
 		req.Email = req.OwnerEmail
 	}
-	recoveryKey, user, err := authService.RegisterFirstUser(req.Email, req.Password, req.OwnerEmail)
+	recoveryKey, user, err := h.auth.RegisterFirstUser(req.Email, req.Password, req.OwnerEmail)
 	if err != nil {
 		return writeError(c, err)
 	}
-	if err := issueSessionCookie(c, user.ID); err != nil {
+	if err := h.issueSessionCookie(c, user.ID); err != nil {
 		return writeError(c, err)
 	}
 	return c.JSON(fiber.Map{"success": true, "recovery_key": recoveryKey})
 }
 
-// Register creates the first account or an additional account when ALLOW_REGISTRATION=true.
-func Register(c *fiber.Ctx) error {
+func (h *AuthHandlers) Register(c *fiber.Ctx) error {
 	var req registerRequest
 	if err := c.BodyParser(&req); err != nil {
 		return writeError(c, services.BadRequest("Invalid request body", err))
 	}
 
-	configured, err := authService.IsConfigured()
+	configured, err := h.auth.IsConfigured()
 	if err != nil {
 		return writeError(c, err)
 	}
 	var recoveryKey string
-	var user models.User
+	var userID string
 	if !configured {
-		recoveryKey, user, err = authService.RegisterFirstUser(req.Email, req.Password, req.OwnerEmail)
+		rk, u, err := h.auth.RegisterFirstUser(req.Email, req.Password, req.OwnerEmail)
+		if err != nil {
+			return writeError(c, err)
+		}
+		recoveryKey, userID = rk, u.ID
 	} else {
-		recoveryKey, user, err = authService.RegisterAdditionalUser(req.Email, req.Password, req.OwnerEmail)
+		rk, u, err := h.auth.RegisterAdditionalUser(req.Email, req.Password, req.OwnerEmail)
+		if err != nil {
+			return writeError(c, err)
+		}
+		recoveryKey, userID = rk, u.ID
 	}
-	if err != nil {
-		return writeError(c, err)
-	}
-	if err := issueSessionCookie(c, user.ID); err != nil {
+	if err := h.issueSessionCookie(c, userID); err != nil {
 		return writeError(c, err)
 	}
 	return c.JSON(fiber.Map{"success": true, "recovery_key": recoveryKey})
 }
 
-// Login authenticates with email and password.
-func Login(c *fiber.Ctx) error {
+func (h *AuthHandlers) Login(c *fiber.Ctx) error {
 	var req loginRequest
 	if err := c.BodyParser(&req); err != nil {
 		return writeError(c, services.BadRequest("Invalid request body", err))
 	}
-	user, err := authService.Login(req.Email, req.Password)
+	user, err := h.auth.Login(req.Email, req.Password)
 	if err != nil {
 		middleware.RecordFailedLogin(c.IP())
 		return writeError(c, err)
 	}
 	middleware.RecordSuccessfulLogin(c.IP())
-	if err := issueSessionCookie(c, user.ID); err != nil {
+	if err := h.issueSessionCookie(c, user.ID); err != nil {
 		return writeError(c, err)
 	}
 	return c.JSON(fiber.Map{"success": true})
 }
 
-func ResetMasterPassword(c *fiber.Ctx) error {
+func (h *AuthHandlers) ResetMasterPassword(c *fiber.Ctx) error {
 	var req struct {
 		Email       string `json:"email"`
 		RecoveryKey string `json:"recovery_key"`
@@ -124,26 +132,25 @@ func ResetMasterPassword(c *fiber.Ctx) error {
 		return writeError(c, services.BadRequest("Invalid request body", err))
 	}
 
-	newRecoveryKey, err := authService.ResetPasswordWithRecovery(req.Email, req.RecoveryKey, req.NewPassword)
+	newRecoveryKey, err := h.auth.ResetPasswordWithRecovery(req.Email, req.RecoveryKey, req.NewPassword)
 	if err != nil {
 		middleware.RecordFailedLogin(c.IP())
 		return writeError(c, err)
 	}
 	middleware.RecordSuccessfulLogin(c.IP())
 
-	user, err := authService.Login(req.Email, req.NewPassword)
+	user, err := h.auth.Login(req.Email, req.NewPassword)
 	if err != nil {
 		return writeError(c, err)
 	}
-	if err := issueSessionCookie(c, user.ID); err != nil {
+	if err := h.issueSessionCookie(c, user.ID); err != nil {
 		return writeError(c, err)
 	}
-
 	return c.JSON(fiber.Map{"success": true, "recovery_key": newRecoveryKey})
 }
 
-// VerifyMasterPassword is kept for backward compatibility: same as Login with email in body.
-func VerifyMasterPassword(c *fiber.Ctx) error {
+// VerifyMasterPassword is kept for backward compatibility: same as Login.
+func (h *AuthHandlers) VerifyMasterPassword(c *fiber.Ctx) error {
 	var req struct {
 		Email    string `json:"email"`
 		Password string `json:"password"`
@@ -154,34 +161,34 @@ func VerifyMasterPassword(c *fiber.Ctx) error {
 	if req.Email == "" {
 		return writeError(c, services.BadRequest("Email is required", nil))
 	}
-	user, err := authService.Login(req.Email, req.Password)
+	user, err := h.auth.Login(req.Email, req.Password)
 	if err != nil {
 		middleware.RecordFailedLogin(c.IP())
 		return writeError(c, err)
 	}
 	middleware.RecordSuccessfulLogin(c.IP())
-	if err := issueSessionCookie(c, user.ID); err != nil {
+	if err := h.issueSessionCookie(c, user.ID); err != nil {
 		return writeError(c, err)
 	}
 	return c.JSON(fiber.Map{"success": true})
 }
 
-func SessionStatus(c *fiber.Ctx) error {
+func (h *AuthHandlers) SessionStatus(c *fiber.Ctx) error {
 	token := c.Cookies("aeterna_session")
-	userID, err := authService.VerifySessionToken(token)
+	userID, err := h.auth.VerifySessionToken(token)
 	if err != nil {
 		return writeError(c, err)
 	}
 	return c.JSON(fiber.Map{"authorized": true, "user_id": userID})
 }
 
-func Logout(c *fiber.Ctx) error {
+func (h *AuthHandlers) Logout(c *fiber.Ctx) error {
 	clearSessionCookie(c)
 	return c.JSON(fiber.Map{"success": true})
 }
 
-func issueSessionCookie(c *fiber.Ctx, userID string) error {
-	token, exp, err := authService.IssueSessionToken(userID)
+func (h *AuthHandlers) issueSessionCookie(c *fiber.Ctx, userID string) error {
+	token, exp, err := h.auth.IssueSessionToken(userID)
 	if err != nil {
 		return err
 	}

--- a/backend/internal/handlers/farewell_handler.go
+++ b/backend/internal/handlers/farewell_handler.go
@@ -1,0 +1,165 @@
+package handlers
+
+import (
+	"io"
+
+	"github.com/alpyxn/aeterna/backend/internal/ports"
+	"github.com/alpyxn/aeterna/backend/internal/services"
+	"github.com/gofiber/fiber/v2"
+)
+
+// FarewellHandlers groups farewell letter and farewell attachment route handlers.
+type FarewellHandlers struct {
+	farewell ports.FarewellServicePort
+	files    ports.FileServicePort
+}
+
+func NewFarewellHandlers(farewell ports.FarewellServicePort, files ports.FileServicePort) *FarewellHandlers {
+	return &FarewellHandlers{farewell: farewell, files: files}
+}
+
+func (h *FarewellHandlers) List(c *fiber.Ctx) error {
+	userID, err := currentUserID(c)
+	if err != nil {
+		return writeError(c, err)
+	}
+	messageID := c.Params("id")
+
+	letters, err := h.farewell.List(userID, messageID)
+	if err != nil {
+		return writeError(c, err)
+	}
+
+	return c.JSON(letters)
+}
+
+func (h *FarewellHandlers) Create(c *fiber.Ctx) error {
+	userID, err := currentUserID(c)
+	if err != nil {
+		return writeError(c, err)
+	}
+	messageID := c.Params("id")
+
+	var body struct {
+		RecipientEmail string `json:"recipient_email"`
+		Subject        string `json:"subject"`
+		Content        string `json:"content"`
+		DelayMinutes   int    `json:"delay_minutes"`
+	}
+	if err := c.BodyParser(&body); err != nil {
+		return writeError(c, services.BadRequest("Invalid request body", err))
+	}
+
+	letter, err := h.farewell.Create(userID, messageID, body.RecipientEmail, body.Subject, body.Content, body.DelayMinutes)
+	if err != nil {
+		return writeError(c, err)
+	}
+
+	return c.Status(fiber.StatusCreated).JSON(letter)
+}
+
+func (h *FarewellHandlers) Update(c *fiber.Ctx) error {
+	userID, err := currentUserID(c)
+	if err != nil {
+		return writeError(c, err)
+	}
+	messageID := c.Params("id")
+	letterID := c.Params("letterId")
+
+	var body struct {
+		RecipientEmail string `json:"recipient_email"`
+		Subject        string `json:"subject"`
+		Content        string `json:"content"`
+		DelayMinutes   int    `json:"delay_minutes"`
+	}
+	if err := c.BodyParser(&body); err != nil {
+		return writeError(c, services.BadRequest("Invalid request body", err))
+	}
+
+	letter, err := h.farewell.Update(userID, messageID, letterID, body.RecipientEmail, body.Subject, body.Content, body.DelayMinutes)
+	if err != nil {
+		return writeError(c, err)
+	}
+
+	return c.JSON(letter)
+}
+
+func (h *FarewellHandlers) Delete(c *fiber.Ctx) error {
+	userID, err := currentUserID(c)
+	if err != nil {
+		return writeError(c, err)
+	}
+	messageID := c.Params("id")
+	letterID := c.Params("letterId")
+
+	if err := h.farewell.Delete(userID, messageID, letterID); err != nil {
+		return writeError(c, err)
+	}
+
+	return c.JSON(fiber.Map{"success": true, "message": "Farewell letter deleted"})
+}
+
+func (h *FarewellHandlers) UploadAttachment(c *fiber.Ctx) error {
+	userID, err := currentUserID(c)
+	if err != nil {
+		return writeError(c, err)
+	}
+	letterID := c.Params("letterId")
+
+	fileHeader, err := c.FormFile("file")
+	if err != nil {
+		return writeError(c, services.BadRequest("No file provided", err))
+	}
+
+	file, err := fileHeader.Open()
+	if err != nil {
+		return writeError(c, services.BadRequest("Failed to read uploaded file", err))
+	}
+	defer file.Close()
+
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return writeError(c, services.BadRequest("Failed to read file data", err))
+	}
+
+	mimeType := fileHeader.Header.Get("Content-Type")
+	if mimeType == "" {
+		mimeType = "application/octet-stream"
+	}
+
+	attachment, err := h.files.UploadFarewellAttachment(userID, letterID, fileHeader.Filename, mimeType, data)
+	if err != nil {
+		return writeError(c, err)
+	}
+
+	return c.JSON(fiber.Map{"success": true, "attachment": attachment})
+}
+
+func (h *FarewellHandlers) ListAttachments(c *fiber.Ctx) error {
+	userID, err := currentUserID(c)
+	if err != nil {
+		return writeError(c, err)
+	}
+	letterID := c.Params("letterId")
+
+	attachments, err := h.files.ListFarewellAttachmentsByLetterID(userID, letterID)
+	if err != nil {
+		return writeError(c, err)
+	}
+
+	return c.JSON(attachments)
+}
+
+func (h *FarewellHandlers) DeleteAttachment(c *fiber.Ctx) error {
+	userID, err := currentUserID(c)
+	if err != nil {
+		return writeError(c, err)
+	}
+	attachmentID := c.Params("attachmentId")
+
+	if err := h.files.DeleteFarewellAttachment(userID, attachmentID); err != nil {
+		return writeError(c, err)
+	}
+
+	return c.JSON(fiber.Map{"success": true, "message": "Farewell attachment deleted"})
+}

--- a/backend/internal/handlers/heartbeat.go
+++ b/backend/internal/handlers/heartbeat.go
@@ -1,25 +1,29 @@
 package handlers
 
 import (
-	"time"
-
-	"github.com/alpyxn/aeterna/backend/internal/database"
-	"github.com/alpyxn/aeterna/backend/internal/models"
+	"github.com/alpyxn/aeterna/backend/internal/ports"
 	"github.com/alpyxn/aeterna/backend/internal/services"
 	"github.com/gofiber/fiber/v2"
-	"gorm.io/gorm"
 )
 
-var settingsService = services.SettingsService{}
+// HeartbeatHandlers groups quick-heartbeat and token route handlers.
+type HeartbeatHandlers struct {
+	messages ports.MessageServicePort
+	settings ports.SettingsServicePort
+}
 
-// QuickHeartbeat handles heartbeat via token link (no auth required)
-func QuickHeartbeat(c *fiber.Ctx) error {
+func NewHeartbeatHandlers(messages ports.MessageServicePort, settings ports.SettingsServicePort) *HeartbeatHandlers {
+	return &HeartbeatHandlers{messages: messages, settings: settings}
+}
+
+// QuickHeartbeat handles token-based heartbeat (no session auth required).
+func (h *HeartbeatHandlers) QuickHeartbeat(c *fiber.Ctx) error {
 	token := c.Params("token")
 	if token == "" {
 		return c.Status(400).JSON(fiber.Map{"error": "Token required"})
 	}
 
-	settings, err := settingsService.GetByHeartbeatToken(token)
+	settings, err := h.settings.GetByHeartbeatToken(token)
 	if err != nil {
 		return writeError(c, err)
 	}
@@ -27,25 +31,7 @@ func QuickHeartbeat(c *fiber.Ctx) error {
 	userID := settings.UserID
 
 	if c.Method() == "POST" {
-		err = database.DB.Transaction(func(tx *gorm.DB) error {
-			now := time.Now().UTC()
-
-			if err := database.TenantTx(tx, userID).Model(&models.Message{}).
-				Where("status = ?", models.StatusActive).
-				Update("last_seen", now).Error; err != nil {
-				return err
-			}
-
-			if err := tx.Model(&models.MessageReminder{}).
-				Where("message_id IN (SELECT id FROM messages WHERE user_id = ? AND status = ?)", userID, models.StatusActive).
-				Update("sent", false).Error; err != nil {
-				return err
-			}
-
-			return nil
-		})
-
-		if err != nil {
+		if err := h.messages.BulkHeartbeat(userID); err != nil {
 			return writeError(c, services.Internal("Failed to update heartbeats", err))
 		}
 
@@ -56,10 +42,10 @@ func QuickHeartbeat(c *fiber.Ctx) error {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>
-        body { 
+        body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-            background: #fafafa; 
-            color: #333; 
+            background: #fafafa;
+            color: #333;
             min-height: 100vh;
             display: flex;
             align-items: center;
@@ -96,10 +82,10 @@ func QuickHeartbeat(c *fiber.Ctx) error {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>
-        body { 
+        body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-            color: #333; 
+            color: #333;
             min-height: 100vh;
             display: flex;
             align-items: center;
@@ -116,14 +102,14 @@ func QuickHeartbeat(c *fiber.Ctx) error {
             max-width: 400px;
             width: 100%;
         }
-        h1 { 
-            font-size: 1.5rem; 
-            font-weight: 600; 
+        h1 {
+            font-size: 1.5rem;
+            font-weight: 600;
             margin-bottom: 0.5rem;
             color: #1a1a1a;
         }
-        p { 
-            color: #666; 
+        p {
+            color: #666;
             font-size: 0.95rem;
             margin-bottom: 2rem;
             line-height: 1.5;
@@ -153,10 +139,10 @@ func QuickHeartbeat(c *fiber.Ctx) error {
             cursor: not-allowed;
             transform: none;
         }
-        .footer { 
-            margin-top: 2rem; 
-            font-size: 0.75rem; 
-            color: #999; 
+        .footer {
+            margin-top: 2rem;
+            font-size: 0.75rem;
+            color: #999;
         }
         .loading {
             display: none;
@@ -182,10 +168,10 @@ func QuickHeartbeat(c *fiber.Ctx) error {
             e.preventDefault();
             const button = document.getElementById('heartbeatButton');
             const loading = document.getElementById('loading');
-            
+
             button.disabled = true;
             loading.style.display = 'block';
-            
+
             fetch(window.location.href, {
                 method: 'POST',
                 headers: {
@@ -215,13 +201,13 @@ func QuickHeartbeat(c *fiber.Ctx) error {
 	return c.SendString(html)
 }
 
-// GetHeartbeatToken returns the heartbeat token for authenticated users
-func GetHeartbeatToken(c *fiber.Ctx) error {
+// GetToken returns the quick-heartbeat token for the authenticated user.
+func (h *HeartbeatHandlers) GetToken(c *fiber.Ctx) error {
 	userID, err := currentUserID(c)
 	if err != nil {
 		return writeError(c, err)
 	}
-	settings, err := settingsService.Get(userID)
+	settings, err := h.settings.Get(userID)
 	if err != nil {
 		return writeError(c, err)
 	}

--- a/backend/internal/handlers/message.go
+++ b/backend/internal/handlers/message.go
@@ -3,6 +3,8 @@ package handlers
 import (
 	"strings"
 
+	"github.com/alpyxn/aeterna/backend/internal/models"
+	"github.com/alpyxn/aeterna/backend/internal/ports"
 	"github.com/alpyxn/aeterna/backend/internal/services"
 	"github.com/gofiber/fiber/v2"
 )
@@ -15,13 +17,24 @@ type CreateMessageRequest struct {
 	Reminders       []int    `json:"reminders"`
 }
 
-type HeartbeatRequest struct {
-	ID string `json:"id"`
+type UpdateMessageRequest struct {
+	Content         string   `json:"content"`
+	RecipientEmail  string   `json:"recipient_email"`
+	RecipientEmails []string `json:"recipient_emails"`
+	TriggerDuration int      `json:"trigger_duration"`
+	Reminders       []int    `json:"reminders"`
 }
 
-var messageService = services.MessageService{}
+// MessageHandlers groups all switch message route handlers.
+type MessageHandlers struct {
+	messages ports.MessageServicePort
+}
 
-func CreateMessage(c *fiber.Ctx) error {
+func NewMessageHandlers(messages ports.MessageServicePort) *MessageHandlers {
+	return &MessageHandlers{messages: messages}
+}
+
+func (h *MessageHandlers) Create(c *fiber.Ctx) error {
 	userID, err := currentUserID(c)
 	if err != nil {
 		return writeError(c, err)
@@ -36,7 +49,7 @@ func CreateMessage(c *fiber.Ctx) error {
 		recipients = []string{strings.TrimSpace(req.RecipientEmail)}
 	}
 
-	msg, err := messageService.Create(userID, req.Content, recipients, req.TriggerDuration, req.Reminders)
+	msg, err := h.messages.Create(userID, req.Content, recipients, req.TriggerDuration, req.Reminders)
 	if err != nil {
 		return writeError(c, err)
 	}
@@ -44,6 +57,97 @@ func CreateMessage(c *fiber.Ctx) error {
 	return c.JSON(fiber.Map{
 		"id":      msg.ID,
 		"message": "Dead man's switch activated!",
+	})
+}
+
+// GetPublic reveals content only when the message is triggered (unauthenticated endpoint).
+func (h *MessageHandlers) GetPublic(c *fiber.Ctx) error {
+	id := c.Params("id")
+	msg, err := h.messages.GetPublicByID(id)
+	if err != nil {
+		return writeError(c, err)
+	}
+
+	content := ""
+	if msg.Status == models.StatusTriggered {
+		content = msg.Content
+	}
+
+	return c.JSON(fiber.Map{
+		"content":    content,
+		"status":     msg.Status,
+		"created_at": msg.CreatedAt,
+	})
+}
+
+func (h *MessageHandlers) Heartbeat(c *fiber.Ctx) error {
+	userID, err := currentUserID(c)
+	if err != nil {
+		return writeError(c, err)
+	}
+	req := new(struct {
+		ID string `json:"id"`
+	})
+	if err := c.BodyParser(req); err != nil {
+		return writeError(c, services.BadRequest("Invalid request body", err))
+	}
+
+	msg, err := h.messages.Heartbeat(userID, req.ID)
+	if err != nil {
+		return writeError(c, err)
+	}
+
+	return c.JSON(fiber.Map{"status": "alive", "last_seen": msg.LastSeen})
+}
+
+func (h *MessageHandlers) List(c *fiber.Ctx) error {
+	userID, err := currentUserID(c)
+	if err != nil {
+		return writeError(c, err)
+	}
+	messages, err := h.messages.List(userID)
+	if err != nil {
+		return writeError(c, err)
+	}
+	return c.JSON(messages)
+}
+
+func (h *MessageHandlers) Delete(c *fiber.Ctx) error {
+	userID, err := currentUserID(c)
+	if err != nil {
+		return writeError(c, err)
+	}
+	id := c.Params("id")
+	if err := h.messages.Delete(userID, id); err != nil {
+		return writeError(c, err)
+	}
+	return c.JSON(fiber.Map{"success": true, "message": "Message deleted successfully"})
+}
+
+func (h *MessageHandlers) Update(c *fiber.Ctx) error {
+	userID, err := currentUserID(c)
+	if err != nil {
+		return writeError(c, err)
+	}
+	id := c.Params("id")
+	req := new(UpdateMessageRequest)
+	if err := c.BodyParser(req); err != nil {
+		return writeError(c, services.BadRequest("Invalid request body", err))
+	}
+
+	recipients := normalizeRecipients(req.RecipientEmails)
+	if len(recipients) == 0 && strings.TrimSpace(req.RecipientEmail) != "" {
+		recipients = []string{strings.TrimSpace(req.RecipientEmail)}
+	}
+
+	msg, err := h.messages.Update(userID, id, req.Content, recipients, req.TriggerDuration, req.Reminders)
+	if err != nil {
+		return writeError(c, err)
+	}
+
+	return c.JSON(fiber.Map{
+		"success": true,
+		"message": msg,
 	})
 }
 
@@ -72,101 +176,4 @@ func normalizeRecipients(recipients []string) []string {
 	}
 
 	return normalized
-}
-
-// GetMessage is public: reveal content only when message is triggered (unchanged contract).
-func GetMessage(c *fiber.Ctx) error {
-	id := c.Params("id")
-	msg, err := messageService.GetPublicByID(id)
-	if err != nil {
-		return writeError(c, err)
-	}
-
-	content := ""
-	if string(msg.Status) == "triggered" {
-		content = msg.Content
-	}
-
-	return c.JSON(fiber.Map{
-		"content":    content,
-		"status":     msg.Status,
-		"created_at": msg.CreatedAt,
-	})
-}
-
-func Heartbeat(c *fiber.Ctx) error {
-	userID, err := currentUserID(c)
-	if err != nil {
-		return writeError(c, err)
-	}
-	req := new(HeartbeatRequest)
-	if err := c.BodyParser(req); err != nil {
-		return writeError(c, services.BadRequest("Invalid request body", err))
-	}
-
-	msg, err := messageService.Heartbeat(userID, req.ID)
-	if err != nil {
-		return writeError(c, err)
-	}
-
-	return c.JSON(fiber.Map{"status": "alive", "last_seen": msg.LastSeen})
-}
-
-func ListMessages(c *fiber.Ctx) error {
-	userID, err := currentUserID(c)
-	if err != nil {
-		return writeError(c, err)
-	}
-	messages, err := messageService.List(userID)
-	if err != nil {
-		return writeError(c, err)
-	}
-	return c.JSON(messages)
-}
-
-func DeleteMessage(c *fiber.Ctx) error {
-	userID, err := currentUserID(c)
-	if err != nil {
-		return writeError(c, err)
-	}
-	id := c.Params("id")
-	if err := messageService.Delete(userID, id); err != nil {
-		return writeError(c, err)
-	}
-	return c.JSON(fiber.Map{"success": true, "message": "Message deleted successfully"})
-}
-
-type UpdateMessageRequest struct {
-	Content         string   `json:"content"`
-	RecipientEmail  string   `json:"recipient_email"`
-	RecipientEmails []string `json:"recipient_emails"`
-	TriggerDuration int      `json:"trigger_duration"`
-	Reminders       []int    `json:"reminders"`
-}
-
-func UpdateMessage(c *fiber.Ctx) error {
-	userID, err := currentUserID(c)
-	if err != nil {
-		return writeError(c, err)
-	}
-	id := c.Params("id")
-	req := new(UpdateMessageRequest)
-	if err := c.BodyParser(req); err != nil {
-		return writeError(c, services.BadRequest("Invalid request body", err))
-	}
-
-	recipients := normalizeRecipients(req.RecipientEmails)
-	if len(recipients) == 0 && strings.TrimSpace(req.RecipientEmail) != "" {
-		recipients = []string{strings.TrimSpace(req.RecipientEmail)}
-	}
-
-	msg, err := messageService.Update(userID, id, req.Content, recipients, req.TriggerDuration, req.Reminders)
-	if err != nil {
-		return writeError(c, err)
-	}
-
-	return c.JSON(fiber.Map{
-		"success": true,
-		"message": msg,
-	})
 }

--- a/backend/internal/handlers/settings.go
+++ b/backend/internal/handlers/settings.go
@@ -2,11 +2,10 @@ package handlers
 
 import (
 	"github.com/alpyxn/aeterna/backend/internal/models"
+	"github.com/alpyxn/aeterna/backend/internal/ports"
 	"github.com/alpyxn/aeterna/backend/internal/services"
 	"github.com/gofiber/fiber/v2"
 )
-
-var applicationSettingsService = services.ApplicationSettingsService{}
 
 // settingsResponse embeds tenant settings and adds global registration flags.
 type settingsResponse struct {
@@ -15,27 +14,37 @@ type settingsResponse struct {
 	CanManageRegistration bool `json:"can_manage_registration"`
 }
 
-func GetSettings(c *fiber.Ctx) error {
+// SettingsHandlers groups SMTP settings and application configuration handlers.
+type SettingsHandlers struct {
+	settings    ports.SettingsServicePort
+	appSettings ports.ApplicationSettingsServicePort
+}
+
+func NewSettingsHandlers(settings ports.SettingsServicePort, appSettings ports.ApplicationSettingsServicePort) *SettingsHandlers {
+	return &SettingsHandlers{settings: settings, appSettings: appSettings}
+}
+
+func (h *SettingsHandlers) Get(c *fiber.Ctx) error {
 	userID, err := currentUserID(c)
 	if err != nil {
 		return writeError(c, err)
 	}
-	settings, err := settingsService.Get(userID)
+	settings, err := h.settings.Get(userID)
 	if err != nil {
 		return writeError(c, err)
 	}
-	app, err := applicationSettingsService.Get()
+	app, err := h.appSettings.Get()
 	if err != nil {
 		return writeError(c, err)
 	}
 	return c.JSON(settingsResponse{
 		Settings:              settings,
 		AllowRegistration:     app.AllowRegistration,
-		CanManageRegistration: services.IsFirstUser(userID),
+		CanManageRegistration: h.appSettings.CanManageRegistration(userID),
 	})
 }
 
-func SaveSettings(c *fiber.Ctx) error {
+func (h *SettingsHandlers) Save(c *fiber.Ctx) error {
 	userID, err := currentUserID(c)
 	if err != nil {
 		return writeError(c, err)
@@ -44,18 +53,18 @@ func SaveSettings(c *fiber.Ctx) error {
 	if err := c.BodyParser(&req); err != nil {
 		return writeError(c, services.BadRequest("Invalid request body", err))
 	}
-	if req.AllowRegistration != nil && services.IsFirstUser(userID) {
-		if err := applicationSettingsService.SetAllowRegistration(userID, *req.AllowRegistration); err != nil {
+	if req.AllowRegistration != nil {
+		if err := h.appSettings.SetAllowRegistration(userID, *req.AllowRegistration); err != nil {
 			return writeError(c, err)
 		}
 	}
-	if err := settingsService.Save(userID, req.ToSettings()); err != nil {
+	if err := h.settings.Save(userID, req.ToSettings()); err != nil {
 		return writeError(c, err)
 	}
 	return c.JSON(fiber.Map{"success": true})
 }
 
-func TestSMTP(c *fiber.Ctx) error {
+func (h *SettingsHandlers) TestSMTP(c *fiber.Ctx) error {
 	if _, err := currentUserID(c); err != nil {
 		return writeError(c, err)
 	}
@@ -63,7 +72,7 @@ func TestSMTP(c *fiber.Ctx) error {
 	if err := c.BodyParser(&req); err != nil {
 		return writeError(c, services.BadRequest("Invalid request body", err))
 	}
-	if err := settingsService.TestSMTP(req.ToSettings()); err != nil {
+	if err := h.settings.TestSMTP(req.ToSettings()); err != nil {
 		return writeError(c, err)
 	}
 	return c.JSON(fiber.Map{"success": true, "message": "Connection successful"})

--- a/backend/internal/handlers/users.go
+++ b/backend/internal/handlers/users.go
@@ -1,33 +1,40 @@
 package handlers
 
 import (
-	"github.com/alpyxn/aeterna/backend/internal/services"
+	"github.com/alpyxn/aeterna/backend/internal/ports"
 	"github.com/gofiber/fiber/v2"
 )
 
-var userAdminService = services.UserAdminService{}
+// UserHandlers groups administrative user management route handlers.
+type UserHandlers struct {
+	users ports.UserAdminServicePort
+}
 
-// ListUsers returns all accounts (primary administrator only).
-func ListUsers(c *fiber.Ctx) error {
+func NewUserHandlers(users ports.UserAdminServicePort) *UserHandlers {
+	return &UserHandlers{users: users}
+}
+
+// List returns all accounts (primary administrator only).
+func (h *UserHandlers) List(c *fiber.Ctx) error {
 	actorID, err := currentUserID(c)
 	if err != nil {
 		return writeError(c, err)
 	}
-	users, err := userAdminService.List(actorID)
+	users, err := h.users.List(actorID)
 	if err != nil {
 		return writeError(c, err)
 	}
 	return c.JSON(users)
 }
 
-// DeleteUser removes a non-primary user (primary administrator only).
-func DeleteUser(c *fiber.Ctx) error {
+// Delete removes a non-primary user (primary administrator only).
+func (h *UserHandlers) Delete(c *fiber.Ctx) error {
 	actorID, err := currentUserID(c)
 	if err != nil {
 		return writeError(c, err)
 	}
 	targetID := c.Params("id")
-	if err := userAdminService.Delete(actorID, targetID); err != nil {
+	if err := h.users.Delete(actorID, targetID); err != nil {
 		return writeError(c, err)
 	}
 	return c.JSON(fiber.Map{"success": true})

--- a/backend/internal/handlers/webhook.go
+++ b/backend/internal/handlers/webhook.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"github.com/alpyxn/aeterna/backend/internal/models"
+	"github.com/alpyxn/aeterna/backend/internal/ports"
 	"github.com/alpyxn/aeterna/backend/internal/services"
 	"github.com/gofiber/fiber/v2"
 )
@@ -12,21 +13,28 @@ type webhookRequest struct {
 	Enabled bool   `json:"enabled"`
 }
 
-var webhookStore = services.WebhookStore{}
+// WebhookHandlers groups webhook CRUD route handlers.
+type WebhookHandlers struct {
+	webhooks ports.WebhookStorePort
+}
 
-func ListWebhooks(c *fiber.Ctx) error {
+func NewWebhookHandlers(webhooks ports.WebhookStorePort) *WebhookHandlers {
+	return &WebhookHandlers{webhooks: webhooks}
+}
+
+func (h *WebhookHandlers) List(c *fiber.Ctx) error {
 	userID, err := currentUserID(c)
 	if err != nil {
 		return writeError(c, err)
 	}
-	items, err := webhookStore.List(userID)
+	items, err := h.webhooks.List(userID)
 	if err != nil {
 		return writeError(c, err)
 	}
 	return c.JSON(items)
 }
 
-func CreateWebhook(c *fiber.Ctx) error {
+func (h *WebhookHandlers) Create(c *fiber.Ctx) error {
 	userID, err := currentUserID(c)
 	if err != nil {
 		return writeError(c, err)
@@ -40,14 +48,14 @@ func CreateWebhook(c *fiber.Ctx) error {
 		Secret:  req.Secret,
 		Enabled: req.Enabled,
 	}
-	created, err := webhookStore.Create(userID, item)
+	created, err := h.webhooks.Create(userID, item)
 	if err != nil {
 		return writeError(c, err)
 	}
 	return c.JSON(created)
 }
 
-func UpdateWebhook(c *fiber.Ctx) error {
+func (h *WebhookHandlers) Update(c *fiber.Ctx) error {
 	userID, err := currentUserID(c)
 	if err != nil {
 		return writeError(c, err)
@@ -62,20 +70,20 @@ func UpdateWebhook(c *fiber.Ctx) error {
 		Secret:  req.Secret,
 		Enabled: req.Enabled,
 	}
-	updated, err := webhookStore.Update(userID, id, item)
+	updated, err := h.webhooks.Update(userID, id, item)
 	if err != nil {
 		return writeError(c, err)
 	}
 	return c.JSON(updated)
 }
 
-func DeleteWebhook(c *fiber.Ctx) error {
+func (h *WebhookHandlers) Delete(c *fiber.Ctx) error {
 	userID, err := currentUserID(c)
 	if err != nil {
 		return writeError(c, err)
 	}
 	id := c.Params("id")
-	if err := webhookStore.Delete(userID, id); err != nil {
+	if err := h.webhooks.Delete(userID, id); err != nil {
 		return writeError(c, err)
 	}
 	return c.JSON(fiber.Map{"success": true})

--- a/backend/internal/models/farewell_attachment.go
+++ b/backend/internal/models/farewell_attachment.go
@@ -1,0 +1,27 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type FarewellAttachment struct {
+	ID          string         `gorm:"type:text;primaryKey" json:"id"`
+	UserID      string         `gorm:"type:text;index" json:"-"`
+	LetterID    string         `gorm:"type:text;not null;index" json:"letter_id"`
+	Filename    string         `gorm:"not null" json:"filename"`
+	StoragePath string         `gorm:"not null" json:"-"`
+	Size        int64          `gorm:"not null" json:"size"`
+	MimeType    string         `gorm:"not null" json:"mime_type"`
+	CreatedAt   time.Time      `json:"created_at"`
+	DeletedAt   gorm.DeletedAt `gorm:"index" json:"-"`
+}
+
+func (a *FarewellAttachment) BeforeCreate(tx *gorm.DB) error {
+	if a.ID == "" {
+		a.ID = uuid.NewString()
+	}
+	return nil
+}

--- a/backend/internal/models/farewell_letter.go
+++ b/backend/internal/models/farewell_letter.go
@@ -1,0 +1,52 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type FarewellLetterStatus string
+
+const (
+	FarewellStatusPending FarewellLetterStatus = "pending"
+	FarewellStatusSent    FarewellLetterStatus = "sent"
+)
+
+type FarewellLetter struct {
+	ID              string               `gorm:"type:text;primaryKey" json:"id"`
+	UserID          string               `gorm:"type:text;index" json:"-"`
+	MessageID       string               `gorm:"type:text;not null;index" json:"message_id"`
+	RecipientEmail  string               `gorm:"not null" json:"recipient_email"`
+	Subject         string               `gorm:"not null" json:"subject"`
+	Content         string               `gorm:"column:encrypted_content;not null" json:"content"`
+	DelayMinutes    int                  `gorm:"not null;default:1440" json:"delay_minutes"`
+	Status          FarewellLetterStatus `gorm:"default:'pending'" json:"status"`
+	SentAt          *time.Time           `json:"sent_at,omitempty"`
+	AttachmentCount int64                `gorm:"-" json:"attachment_count"`
+	CreatedAt       time.Time            `json:"created_at"`
+	UpdatedAt       time.Time            `json:"updated_at"`
+	DeletedAt       gorm.DeletedAt       `gorm:"index" json:"-"`
+}
+
+func (f *FarewellLetter) BeforeCreate(tx *gorm.DB) error {
+	if f.ID == "" {
+		f.ID = uuid.NewString()
+	}
+	return nil
+}
+
+// BeforeDelete cascades the delete to associated FarewellAttachments,
+// mirroring the soft/hard mode of the parent operation.
+// When called from a batch context (f.ID == ""), the parent Message.BeforeDelete handles it.
+func (f *FarewellLetter) BeforeDelete(tx *gorm.DB) error {
+	if f.ID == "" {
+		return nil
+	}
+	db := tx
+	if tx.Statement.Unscoped {
+		db = tx.Unscoped()
+	}
+	return db.Where("letter_id = ?", f.ID).Delete(&FarewellAttachment{}).Error
+}

--- a/backend/internal/models/message.go
+++ b/backend/internal/models/message.go
@@ -24,6 +24,7 @@ type Message struct {
 	TriggerDuration int               `gorm:"not null" json:"trigger_duration"`
 	LastSeen        time.Time         `gorm:"not null;default:CURRENT_TIMESTAMP" json:"last_seen"`
 	Status          MessageStatus     `gorm:"default:'active'" json:"status"`
+	TriggeredAt     *time.Time        `json:"triggered_at,omitempty"`
 	Reminders       []MessageReminder `gorm:"foreignKey:MessageID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;" json:"reminders"`
 	CreatedAt       time.Time         `json:"created_at"`
 	UpdatedAt       time.Time         `json:"updated_at"`
@@ -40,4 +41,27 @@ func (m *Message) BeforeCreate(tx *gorm.DB) error {
 		m.ManagementToken = uuid.NewString()
 	}
 	return nil
+}
+
+// BeforeDelete cascades the delete to associated FarewellLetters and their attachments,
+// mirroring the soft/hard mode of the parent operation.
+func (m *Message) BeforeDelete(tx *gorm.DB) error {
+	if m.ID == "" {
+		return nil
+	}
+	db := tx
+	if tx.Statement.Unscoped {
+		db = tx.Unscoped()
+	}
+	var letterIDs []string
+	if err := db.Model(&FarewellLetter{}).Select("id").Where("message_id = ?", m.ID).Find(&letterIDs).Error; err != nil {
+		return err
+	}
+	if len(letterIDs) == 0 {
+		return nil
+	}
+	if err := db.Where("letter_id IN ?", letterIDs).Delete(&FarewellAttachment{}).Error; err != nil {
+		return err
+	}
+	return db.Where("id IN ?", letterIDs).Delete(&FarewellLetter{}).Error
 }

--- a/backend/internal/models/user.go
+++ b/backend/internal/models/user.go
@@ -22,3 +22,11 @@ func (u *User) BeforeCreate(tx *gorm.DB) error {
 	}
 	return nil
 }
+
+// UserListItem is a projection of a user account for administrative listing.
+type UserListItem struct {
+	ID        string `json:"id"`
+	Email     string `json:"email"`
+	CreatedAt string `json:"created_at"`
+	IsPrimary bool   `json:"is_primary"`
+}

--- a/backend/internal/ports/ports.go
+++ b/backend/internal/ports/ports.go
@@ -1,0 +1,85 @@
+package ports
+
+import (
+	"time"
+
+	"github.com/alpyxn/aeterna/backend/internal/models"
+)
+
+// AuthServicePort covers authentication and session management.
+type AuthServicePort interface {
+	IsConfigured() (bool, error)
+	RegisterFirstUser(email, password, ownerEmail string) (recoveryKey string, user models.User, err error)
+	RegisterAdditionalUser(email, password, ownerEmail string) (recoveryKey string, user models.User, err error)
+	Login(email, password string) (models.User, error)
+	IssueSessionToken(userID string) (string, time.Time, error)
+	VerifySessionToken(token string) (userID string, err error)
+	ResetPasswordWithRecovery(email, recoveryKey, newPassword string) (newRecoveryKey string, err error)
+	AdditionalRegistrationOpen() (bool, error)
+}
+
+// MessageServicePort covers switch lifecycle and heartbeat operations.
+type MessageServicePort interface {
+	Create(userID, content string, recipientEmails []string, triggerDuration int, reminders []int) (models.Message, error)
+	GetPublicByID(id string) (models.Message, error)
+	GetByID(userID, id string) (models.Message, error)
+	List(userID string) ([]models.Message, error)
+	Heartbeat(userID, id string) (models.Message, error)
+	BulkHeartbeat(userID string) error
+	Delete(userID, id string) error
+	Update(userID, id, content string, recipientEmails []string, triggerDuration int, reminders []int) (models.Message, error)
+}
+
+// FileServicePort covers attachment storage for switches and farewell letters.
+type FileServicePort interface {
+	Upload(userID, messageID, filename, mimeType string, data []byte) (models.Attachment, error)
+	Delete(userID, attachmentID string) error
+	DeleteByMessageID(userID, messageID string) error
+	GetDecrypted(userID, attachmentID string) (filename, mimeType string, data []byte, err error)
+	ListByMessageID(userID, messageID string) ([]models.Attachment, error)
+	CountByMessageID(userID, messageID string) (int64, error)
+	UploadFarewellAttachment(userID, letterID, filename, mimeType string, data []byte) (models.FarewellAttachment, error)
+	ListFarewellAttachmentsByLetterID(userID, letterID string) ([]models.FarewellAttachment, error)
+	CountFarewellAttachmentsByLetterID(userID, letterID string) (int64, error)
+	DeleteFarewellAttachment(userID, attachmentID string) error
+	DeleteFarewellAttachmentsByLetterID(userID, letterID string) error
+	GetFarewellAttachmentDecrypted(userID, attachmentID string) (filename, mimeType string, data []byte, err error)
+}
+
+// FarewellServicePort covers farewell letter CRUD scoped to a switch.
+type FarewellServicePort interface {
+	Create(userID, messageID, recipientEmail, subject, content string, delayMinutes int) (models.FarewellLetter, error)
+	List(userID, messageID string) ([]models.FarewellLetter, error)
+	Update(userID, messageID, id, recipientEmail, subject, content string, delayMinutes int) (models.FarewellLetter, error)
+	Delete(userID, messageID, id string) error
+}
+
+// SettingsServicePort covers per-user SMTP and heartbeat token configuration.
+type SettingsServicePort interface {
+	Get(userID string) (models.Settings, error)
+	GetByHeartbeatToken(token string) (models.Settings, error)
+	Save(userID string, req models.Settings) error
+	TestSMTP(req models.Settings) error
+}
+
+// ApplicationSettingsServicePort covers the global (singleton) application settings.
+type ApplicationSettingsServicePort interface {
+	Get() (models.ApplicationSettings, error)
+	SetAllowRegistration(actorUserID string, allow bool) error
+	CanManageRegistration(userID string) bool
+}
+
+// WebhookStorePort covers webhook CRUD for a tenant.
+type WebhookStorePort interface {
+	List(userID string) ([]models.Webhook, error)
+	ListEnabledForUser(userID string) ([]models.Webhook, error)
+	Create(userID string, item models.Webhook) (models.Webhook, error)
+	Update(userID, id string, input models.Webhook) (models.Webhook, error)
+	Delete(userID, id string) error
+}
+
+// UserAdminServicePort covers administrative user account management.
+type UserAdminServicePort interface {
+	List(actorUserID string) ([]models.UserListItem, error)
+	Delete(actorUserID, targetUserID string) error
+}

--- a/backend/internal/services/application_settings_service.go
+++ b/backend/internal/services/application_settings_service.go
@@ -42,6 +42,11 @@ func (s ApplicationSettingsService) SetAllowRegistration(actorUserID string, all
 	return database.DB.Save(&app).Error
 }
 
+// CanManageRegistration returns true if userID is the primary (first) administrator.
+func (s ApplicationSettingsService) CanManageRegistration(userID string) bool {
+	return IsFirstUser(userID)
+}
+
 // EnsureApplicationSettingsRow creates the singleton row if missing.
 func EnsureApplicationSettingsRow() error {
 	var n int64

--- a/backend/internal/services/email_service.go
+++ b/backend/internal/services/email_service.go
@@ -12,6 +12,9 @@ import (
 	"time"
 
 	"github.com/alpyxn/aeterna/backend/internal/models"
+	"github.com/gomarkdown/markdown"
+	"github.com/gomarkdown/markdown/html"
+	"github.com/gomarkdown/markdown/parser"
 )
 
 type EmailService struct{}
@@ -133,16 +136,7 @@ func (s EmailService) SendWithAttachments(settings models.Settings, recipients [
 	buf.WriteString(fmt.Sprintf("--%s--\r\n", boundary))
 
 	message := buf.Bytes()
-	addr := settings.SMTPHost + ":" + settings.SMTPPort
-
-	if settings.SMTPPort == "465" {
-		return s.sendWithRetry(func() error {
-			return s.sendEmailSSL(settings, addr, from, sanitizedRecipients, message)
-		})
-	}
-	return s.sendWithRetry(func() error {
-		return s.sendEmailSTARTTLS(settings, addr, from, sanitizedRecipients, message)
-	})
+	return s.sendRaw(settings, from, sanitizedRecipients, message)
 }
 
 // SendPlain sends a plain text email
@@ -176,15 +170,18 @@ func (s EmailService) SendPlain(settings models.Settings, recipients []string, s
 	headers += "\r\n"
 
 	message := []byte(headers + body)
-	addr := settings.SMTPHost + ":" + settings.SMTPPort
+	return s.sendRaw(settings, from, sanitizedRecipients, message)
+}
 
+func (s EmailService) sendRaw(settings models.Settings, from string, recipients []string, message []byte) error {
+	addr := settings.SMTPHost + ":" + settings.SMTPPort
 	if settings.SMTPPort == "465" {
 		return s.sendWithRetry(func() error {
-			return s.sendEmailSSL(settings, addr, from, sanitizedRecipients, message)
+			return s.sendEmailSSL(settings, addr, from, recipients, message)
 		})
 	}
 	return s.sendWithRetry(func() error {
-		return s.sendEmailSTARTTLS(settings, addr, from, sanitizedRecipients, message)
+		return s.sendEmailSTARTTLS(settings, addr, from, recipients, message)
 	})
 }
 
@@ -343,6 +340,101 @@ func ParseRecipientEmails(value string) []string {
 		return nil
 	}
 	return result
+}
+
+// markdownToHTML converts Markdown content to an HTML string.
+func markdownToHTML(md string) string {
+	extensions := parser.CommonExtensions | parser.AutoHeadingIDs
+	p := parser.NewWithExtensions(extensions)
+	doc := p.Parse([]byte(md))
+
+	opts := html.RendererOptions{Flags: html.CommonFlags | html.HrefTargetBlank}
+	renderer := html.NewRenderer(opts)
+
+	return string(markdown.Render(doc, renderer))
+}
+
+// SendFarewellLetter sends a farewell letter as a multipart HTML email with optional attachments.
+// The content is written in Markdown and rendered to HTML; plain text is sent as fallback.
+func (s EmailService) SendFarewellLetter(settings models.Settings, recipientEmail, subject, mdContent string, attachments []EmailAttachment) error {
+	from := settings.SMTPFrom
+	if from == "" {
+		from = settings.SMTPUser
+	}
+	fromName := settings.SMTPFromName
+	if fromName == "" {
+		fromName = "Aeterna"
+	}
+
+	from = sanitizeEmailHeader(from)
+	fromName = sanitizeEmailHeader(fromName)
+	subject = sanitizeEmailHeader(subject)
+	recipient := sanitizeEmailHeader(recipientEmail)
+
+	htmlBody := markdownToHTML(mdContent)
+	plainBody := mdContent
+
+	outerBoundary := "==AeternaFarewellMixed=="
+	altBoundary := "==AeternaFarewellAlt=="
+
+	var buf bytes.Buffer
+
+	buf.WriteString(fmt.Sprintf("From: %s <%s>\r\n", fromName, from))
+	buf.WriteString(fmt.Sprintf("To: %s\r\n", recipient))
+	buf.WriteString(fmt.Sprintf("Subject: %s\r\n", subject))
+	buf.WriteString("MIME-Version: 1.0\r\n")
+
+	if len(attachments) > 0 {
+		// multipart/mixed wrapping multipart/alternative + attachments
+		buf.WriteString(fmt.Sprintf("Content-Type: multipart/mixed; boundary=\"%s\"\r\n\r\n", outerBoundary))
+
+		buf.WriteString(fmt.Sprintf("--%s\r\n", outerBoundary))
+		buf.WriteString(fmt.Sprintf("Content-Type: multipart/alternative; boundary=\"%s\"\r\n\r\n", altBoundary))
+
+		writeAlternativeParts(&buf, altBoundary, plainBody, htmlBody)
+
+		buf.WriteString(fmt.Sprintf("--%s--\r\n", altBoundary))
+		buf.WriteString("\r\n")
+
+		for _, att := range attachments {
+			buf.WriteString(fmt.Sprintf("--%s\r\n", outerBoundary))
+			buf.WriteString(fmt.Sprintf("Content-Type: %s; name=\"%s\"\r\n", att.MimeType, mime.QEncoding.Encode("utf-8", att.Filename)))
+			buf.WriteString("Content-Transfer-Encoding: base64\r\n")
+			buf.WriteString(fmt.Sprintf("Content-Disposition: attachment; filename=\"%s\"\r\n\r\n", mime.QEncoding.Encode("utf-8", att.Filename)))
+			encoded := base64.StdEncoding.EncodeToString(att.Data)
+			for i := 0; i < len(encoded); i += 76 {
+				end := i + 76
+				if end > len(encoded) {
+					end = len(encoded)
+				}
+				buf.WriteString(encoded[i:end])
+				buf.WriteString("\r\n")
+			}
+		}
+		buf.WriteString(fmt.Sprintf("--%s--\r\n", outerBoundary))
+	} else {
+		// multipart/alternative only
+		buf.WriteString(fmt.Sprintf("Content-Type: multipart/alternative; boundary=\"%s\"\r\n\r\n", altBoundary))
+		writeAlternativeParts(&buf, altBoundary, plainBody, htmlBody)
+		buf.WriteString(fmt.Sprintf("--%s--\r\n", altBoundary))
+	}
+
+	message := buf.Bytes()
+	return s.sendRaw(settings, from, []string{recipient}, message)
+}
+
+func writeAlternativeParts(buf *bytes.Buffer, boundary, plainBody, htmlBody string) {
+	buf.WriteString(fmt.Sprintf("--%s\r\n", boundary))
+	buf.WriteString("Content-Type: text/plain; charset=UTF-8\r\n")
+	buf.WriteString("Content-Transfer-Encoding: 7bit\r\n\r\n")
+	buf.WriteString(plainBody)
+	buf.WriteString("\r\n")
+
+	buf.WriteString(fmt.Sprintf("--%s\r\n", boundary))
+	buf.WriteString("Content-Type: text/html; charset=UTF-8\r\n")
+	buf.WriteString("Content-Transfer-Encoding: 7bit\r\n\r\n")
+	buf.WriteString(htmlBody)
+	buf.WriteString("\r\n")
 }
 
 // emailLoginAuth implements LOGIN authentication mechanism

--- a/backend/internal/services/farewell_service.go
+++ b/backend/internal/services/farewell_service.go
@@ -1,0 +1,158 @@
+package services
+
+import (
+	"errors"
+
+	"github.com/alpyxn/aeterna/backend/internal/database"
+	"github.com/alpyxn/aeterna/backend/internal/models"
+	"gorm.io/gorm"
+)
+
+type FarewellService struct{}
+
+var farewellCrypto = CryptoService{}
+var farewellValidation = ValidationService{}
+var farewellFileService = FileService{}
+
+func (s FarewellService) Create(userID, messageID, recipientEmail, subject, content string, delayMinutes int) (models.FarewellLetter, error) {
+	var msg models.Message
+	if err := database.ForTenant(userID).First(&msg, "id = ?", messageID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return models.FarewellLetter{}, NotFound("Message not found", err)
+		}
+		return models.FarewellLetter{}, Internal("Failed to fetch message", err)
+	}
+
+	if err := farewellValidation.ValidateEmail(recipientEmail); err != nil {
+		return models.FarewellLetter{}, err
+	}
+
+	if subject == "" {
+		return models.FarewellLetter{}, BadRequest("Subject is required", nil)
+	}
+
+	if err := farewellValidation.ValidateContent(content); err != nil {
+		return models.FarewellLetter{}, err
+	}
+
+	if delayMinutes < 0 {
+		return models.FarewellLetter{}, BadRequest("Delay must be zero or positive", nil)
+	}
+
+	encrypted, err := farewellCrypto.Encrypt(content)
+	if err != nil {
+		return models.FarewellLetter{}, err
+	}
+
+	letter := models.FarewellLetter{
+		UserID:         userID,
+		MessageID:      messageID,
+		RecipientEmail: recipientEmail,
+		Subject:        subject,
+		Content:        encrypted,
+		DelayMinutes:   delayMinutes,
+		Status:         models.FarewellStatusPending,
+	}
+
+	if err := database.DB.Create(&letter).Error; err != nil {
+		return models.FarewellLetter{}, Internal("Failed to create farewell letter", err)
+	}
+
+	letter.Content = content
+	return letter, nil
+}
+
+func (s FarewellService) List(userID, messageID string) ([]models.FarewellLetter, error) {
+	var msg models.Message
+	if err := database.ForTenant(userID).First(&msg, "id = ?", messageID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, NotFound("Message not found", err)
+		}
+		return nil, Internal("Failed to fetch message", err)
+	}
+
+	var letters []models.FarewellLetter
+	if err := database.ForTenant(userID).Where("message_id = ?", messageID).Order("created_at ASC").Find(&letters).Error; err != nil {
+		return nil, Internal("Failed to fetch farewell letters", err)
+	}
+
+	for i := range letters {
+		decrypted, err := farewellCrypto.Decrypt(letters[i].Content)
+		if err != nil {
+			return nil, err
+		}
+		letters[i].Content = decrypted
+
+		count, _ := farewellFileService.CountFarewellAttachmentsByLetterID(userID, letters[i].ID)
+		letters[i].AttachmentCount = count
+	}
+
+	return letters, nil
+}
+
+func (s FarewellService) Update(userID, messageID, id, recipientEmail, subject, content string, delayMinutes int) (models.FarewellLetter, error) {
+	var letter models.FarewellLetter
+	if err := database.ForTenant(userID).Where("message_id = ? AND id = ?", messageID, id).First(&letter).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return models.FarewellLetter{}, NotFound("Farewell letter not found", err)
+		}
+		return models.FarewellLetter{}, Internal("Failed to fetch farewell letter", err)
+	}
+
+	if letter.Status == models.FarewellStatusSent {
+		return models.FarewellLetter{}, BadRequest("Cannot edit an already-sent farewell letter", nil)
+	}
+
+	if err := farewellValidation.ValidateEmail(recipientEmail); err != nil {
+		return models.FarewellLetter{}, err
+	}
+
+	if subject == "" {
+		return models.FarewellLetter{}, BadRequest("Subject is required", nil)
+	}
+
+	if err := farewellValidation.ValidateContent(content); err != nil {
+		return models.FarewellLetter{}, err
+	}
+
+	if delayMinutes < 0 {
+		return models.FarewellLetter{}, BadRequest("Delay must be zero or positive", nil)
+	}
+
+	encrypted, err := farewellCrypto.Encrypt(content)
+	if err != nil {
+		return models.FarewellLetter{}, err
+	}
+
+	letter.RecipientEmail = recipientEmail
+	letter.Subject = subject
+	letter.Content = encrypted
+	letter.DelayMinutes = delayMinutes
+
+	if err := database.ForTenant(userID).Save(&letter).Error; err != nil {
+		return models.FarewellLetter{}, Internal("Failed to update farewell letter", err)
+	}
+
+	letter.Content = content
+	return letter, nil
+}
+
+func (s FarewellService) Delete(userID, messageID, id string) error {
+	var letter models.FarewellLetter
+	if err := database.ForTenant(userID).Where("message_id = ? AND id = ?", messageID, id).First(&letter).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return NotFound("Farewell letter not found", err)
+		}
+		return Internal("Failed to fetch farewell letter", err)
+	}
+
+	if err := farewellFileService.DeleteFarewellAttachmentsByLetterID(userID, id); err != nil {
+		return Internal("Failed to delete farewell attachments", err)
+	}
+
+	if err := database.ForTenant(userID).Unscoped().Delete(&letter).Error; err != nil {
+		return Internal("Failed to delete farewell letter", err)
+	}
+
+	return nil
+}

--- a/backend/internal/services/file_service.go
+++ b/backend/internal/services/file_service.go
@@ -187,3 +187,156 @@ func (s FileService) CountByMessageID(userID, messageID string) (int64, error) {
 	}
 	return count, nil
 }
+
+// UploadFarewellAttachment validates, encrypts, and stores a file for a farewell letter.
+func (s FileService) UploadFarewellAttachment(userID, letterID, filename, mimeType string, data []byte) (models.FarewellAttachment, error) {
+	var letter models.FarewellLetter
+	if err := database.ForTenant(userID).First(&letter, "id = ?", letterID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return models.FarewellAttachment{}, NotFound("Farewell letter not found", err)
+		}
+		return models.FarewellAttachment{}, Internal("Failed to fetch farewell letter", err)
+	}
+
+	if letter.Status == models.FarewellStatusSent {
+		return models.FarewellAttachment{}, BadRequest("Cannot attach files to an already-sent farewell letter", nil)
+	}
+
+	cleanFilename := fileValidationService.SanitizeFilename(filename)
+	if err := fileValidationService.ValidateFarewellFile(cleanFilename, int64(len(data)), data); err != nil {
+		return models.FarewellAttachment{}, err
+	}
+
+	var existingCount int64
+	database.ForTenant(userID).Model(&models.FarewellAttachment{}).Where("letter_id = ?", letterID).Count(&existingCount)
+	if existingCount >= int64(MaxFarewellAttachments) {
+		return models.FarewellAttachment{}, BadRequest(fmt.Sprintf("Maximum %d attachments per farewell letter", MaxFarewellAttachments), nil)
+	}
+
+	var totalSize int64
+	database.ForTenant(userID).Model(&models.FarewellAttachment{}).Where("letter_id = ?", letterID).Select("COALESCE(SUM(size), 0)").Scan(&totalSize)
+	if totalSize+int64(len(data)) > MaxFarewellTotalSize {
+		return models.FarewellAttachment{}, BadRequest("Total attachment size exceeds 50 MB limit", nil)
+	}
+
+	encrypted, err := fileCryptoService.EncryptBytes(data)
+	if err != nil {
+		return models.FarewellAttachment{}, Internal("Failed to encrypt file", err)
+	}
+
+	letterDir := filepath.Join(GetUploadsDir(), userID, "farewell", letterID)
+	if err := os.MkdirAll(letterDir, 0700); err != nil {
+		return models.FarewellAttachment{}, Internal("Failed to create upload directory", err)
+	}
+
+	storageFilename := uuid.NewString() + ".enc"
+	storagePath := filepath.Join(letterDir, storageFilename)
+
+	if err := os.WriteFile(storagePath, encrypted, 0600); err != nil {
+		return models.FarewellAttachment{}, Internal("Failed to write file", err)
+	}
+
+	attachment := models.FarewellAttachment{
+		UserID:      userID,
+		LetterID:    letterID,
+		Filename:    cleanFilename,
+		StoragePath: storagePath,
+		Size:        int64(len(data)),
+		MimeType:    mimeType,
+	}
+
+	if err := database.DB.Create(&attachment).Error; err != nil {
+		os.Remove(storagePath)
+		return models.FarewellAttachment{}, Internal("Failed to save attachment record", err)
+	}
+
+	slog.Info("Farewell attachment uploaded", "attachment_id", attachment.ID, "letter_id", letterID, "filename", cleanFilename)
+	return attachment, nil
+}
+
+// ListFarewellAttachmentsByLetterID returns all attachments for a farewell letter.
+func (s FileService) ListFarewellAttachmentsByLetterID(userID, letterID string) ([]models.FarewellAttachment, error) {
+	var attachments []models.FarewellAttachment
+	if err := database.ForTenant(userID).Where("letter_id = ?", letterID).Order("created_at ASC").Find(&attachments).Error; err != nil {
+		return nil, Internal("Failed to fetch farewell attachments", err)
+	}
+	return attachments, nil
+}
+
+// CountFarewellAttachmentsByLetterID returns the number of attachments for a farewell letter.
+func (s FileService) CountFarewellAttachmentsByLetterID(userID, letterID string) (int64, error) {
+	var count int64
+	if err := database.ForTenant(userID).Model(&models.FarewellAttachment{}).Where("letter_id = ?", letterID).Count(&count).Error; err != nil {
+		return 0, Internal("Failed to count farewell attachments", err)
+	}
+	return count, nil
+}
+
+// DeleteFarewellAttachment removes a single farewell attachment (file + DB record).
+func (s FileService) DeleteFarewellAttachment(userID, attachmentID string) error {
+	var attachment models.FarewellAttachment
+	if err := database.ForTenant(userID).First(&attachment, "id = ?", attachmentID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return NotFound("Farewell attachment not found", err)
+		}
+		return Internal("Failed to fetch farewell attachment", err)
+	}
+
+	if err := os.Remove(attachment.StoragePath); err != nil && !os.IsNotExist(err) {
+		slog.Error("Failed to remove farewell attachment file", "path", attachment.StoragePath, "error", err)
+	}
+
+	if err := database.DB.Unscoped().Delete(&attachment).Error; err != nil {
+		return Internal("Failed to delete farewell attachment record", err)
+	}
+
+	slog.Info("Farewell attachment deleted", "attachment_id", attachmentID)
+	return nil
+}
+
+// DeleteFarewellAttachmentsByLetterID removes all attachments for a farewell letter.
+func (s FileService) DeleteFarewellAttachmentsByLetterID(userID, letterID string) error {
+	var attachments []models.FarewellAttachment
+	if err := database.ForTenant(userID).Where("letter_id = ?", letterID).Find(&attachments).Error; err != nil {
+		return Internal("Failed to fetch farewell attachments", err)
+	}
+
+	for _, att := range attachments {
+		if err := os.Remove(att.StoragePath); err != nil && !os.IsNotExist(err) {
+			slog.Error("Failed to remove farewell attachment file", "path", att.StoragePath, "error", err)
+		}
+	}
+
+	if err := database.ForTenant(userID).Unscoped().Where("letter_id = ?", letterID).Delete(&models.FarewellAttachment{}).Error; err != nil {
+		return Internal("Failed to delete farewell attachment records", err)
+	}
+
+	letterDir := filepath.Join(GetUploadsDir(), userID, "farewell", letterID)
+	os.Remove(letterDir)
+
+	slog.Info("All farewell attachments deleted", "letter_id", letterID)
+	return nil
+}
+
+// GetFarewellAttachmentDecrypted reads and decrypts a farewell attachment.
+func (s FileService) GetFarewellAttachmentDecrypted(userID, attachmentID string) (filename, mimeType string, data []byte, err error) {
+	var attachment models.FarewellAttachment
+	if err := database.ForTenant(userID).First(&attachment, "id = ?", attachmentID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return "", "", nil, NotFound("Farewell attachment not found", err)
+		}
+		return "", "", nil, Internal("Failed to fetch farewell attachment", err)
+	}
+
+	encrypted, err := os.ReadFile(attachment.StoragePath)
+	if err != nil {
+		return "", "", nil, Internal("Failed to read farewell attachment file", err)
+	}
+
+	decrypted, err := fileCryptoService.DecryptBytes(encrypted)
+	if err != nil {
+		return "", "", nil, Internal("Failed to decrypt farewell attachment", err)
+	}
+
+	return attachment.Filename, attachment.MimeType, decrypted, nil
+}

--- a/backend/internal/services/message_service.go
+++ b/backend/internal/services/message_service.go
@@ -191,11 +191,40 @@ func (s MessageService) Delete(userID, id string) error {
 		return Internal("Failed to delete attachments", err)
 	}
 
-	if err := database.DB.Unscoped().Delete(&msg).Error; err != nil {
+	// Filesystem cleanup for farewell letter attachments; DB records are cascaded by Message.BeforeDelete.
+	var letters []models.FarewellLetter
+	if err := database.ForTenant(userID).Where("message_id = ?", id).Find(&letters).Error; err != nil {
+		return Internal("Failed to fetch farewell letters", err)
+	}
+	for _, letter := range letters {
+		if err := msgFileService.DeleteFarewellAttachmentsByLetterID(userID, letter.ID); err != nil {
+			return Internal("Failed to delete farewell letter attachments", err)
+		}
+	}
+
+	if err := database.ForTenant(userID).Unscoped().Delete(&msg).Error; err != nil {
 		return Internal("Failed to delete message", err)
 	}
 
 	return nil
+}
+
+// BulkHeartbeat resets last_seen for all active messages of a user and clears sent reminders.
+func (s MessageService) BulkHeartbeat(userID string) error {
+	now := time.Now().UTC()
+	return database.DB.Transaction(func(tx *gorm.DB) error {
+		if err := database.TenantTx(tx, userID).Model(&models.Message{}).
+			Where("status = ?", models.StatusActive).
+			Update("last_seen", now).Error; err != nil {
+			return Internal("failed to update heartbeats", err)
+		}
+		if err := tx.Model(&models.MessageReminder{}).
+			Where("message_id IN (SELECT id FROM messages WHERE user_id = ? AND status = ?)", userID, models.StatusActive).
+			Update("sent", false).Error; err != nil {
+			return Internal("failed to reset reminders", err)
+		}
+		return nil
+	})
 }
 
 func (s MessageService) Update(userID, id, content string, recipientEmails []string, triggerDuration int, reminders []int) (models.Message, error) {
@@ -240,7 +269,7 @@ func (s MessageService) Update(userID, id, content string, recipientEmails []str
 	msg.TriggerDuration = triggerDuration
 	msg.LastSeen = time.Now()
 	err = database.DB.Transaction(func(tx *gorm.DB) error {
-		if err := tx.Save(&msg).Error; err != nil {
+		if err := database.TenantTx(tx, userID).Save(&msg).Error; err != nil {
 			return Internal("Failed to update message", err)
 		}
 

--- a/backend/internal/services/user_admin_service.go
+++ b/backend/internal/services/user_admin_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"errors"
+	"log/slog"
 	"os"
 	"path/filepath"
 
@@ -13,16 +14,8 @@ import (
 // UserAdminService manages accounts for the primary administrator only.
 type UserAdminService struct{}
 
-// UserListItem is a safe view of a user for admin listing.
-type UserListItem struct {
-	ID        string `json:"id"`
-	Email     string `json:"email"`
-	CreatedAt string `json:"created_at"`
-	IsPrimary bool   `json:"is_primary"`
-}
-
 // List returns all accounts when the actor is the primary (first) user.
-func (s UserAdminService) List(actorUserID string) ([]UserListItem, error) {
+func (s UserAdminService) List(actorUserID string) ([]models.UserListItem, error) {
 	if !IsFirstUser(actorUserID) {
 		return nil, NewAPIError(403, "forbidden", "Only the primary administrator can list users.", nil)
 	}
@@ -30,7 +23,7 @@ func (s UserAdminService) List(actorUserID string) ([]UserListItem, error) {
 	var first models.User
 	if err := database.DB.Order("created_at ASC, id ASC").First(&first).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return []UserListItem{}, nil
+			return []models.UserListItem{}, nil
 		}
 		return nil, Internal("Failed to resolve primary user", err)
 	}
@@ -40,9 +33,9 @@ func (s UserAdminService) List(actorUserID string) ([]UserListItem, error) {
 		return nil, Internal("Failed to list users", err)
 	}
 
-	out := make([]UserListItem, 0, len(users))
+	out := make([]models.UserListItem, 0, len(users))
 	for _, u := range users {
-		out = append(out, UserListItem{
+		out = append(out, models.UserListItem{
 			ID:        u.ID,
 			Email:     u.Email,
 			CreatedAt: u.CreatedAt.UTC().Format("2006-01-02T15:04:05Z"),
@@ -85,6 +78,16 @@ func (s UserAdminService) Delete(actorUserID, targetUserID string) error {
 	for _, msg := range msgs {
 		if err := fs.DeleteByMessageID(targetUserID, msg.ID); err != nil {
 			return err
+		}
+		// Filesystem cleanup for farewell letter attachments; DB records handled by Message.BeforeDelete.
+		var letters []models.FarewellLetter
+		if err := database.DB.Unscoped().Where("message_id = ?", msg.ID).Find(&letters).Error; err != nil {
+			slog.Error("Failed to list farewell letters for cleanup", "message_id", msg.ID, "error", err)
+		}
+		for _, letter := range letters {
+			if err := fs.DeleteFarewellAttachmentsByLetterID(targetUserID, letter.ID); err != nil {
+				slog.Error("Failed to delete farewell attachments during user deletion", "letter_id", letter.ID, "error", err)
+			}
 		}
 	}
 

--- a/backend/internal/services/validation.go
+++ b/backend/internal/services/validation.go
@@ -19,6 +19,11 @@ const (
 	MaxFileSize          = 10 * 1024 * 1024 // 10 MB
 	MaxTotalAttachSize   = 25 * 1024 * 1024 // 25 MB
 	MaxAttachmentsPerMsg = 5
+
+	// Farewell letter attachments use email-provider limits as the practical ceiling.
+	MaxFarewellFileSize    = 20 * 1024 * 1024 // 20 MB per file
+	MaxFarewellTotalSize   = 50 * 1024 * 1024 // 50 MB total
+	MaxFarewellAttachments = 10
 )
 
 var AllowedExtensions = map[string]bool{
@@ -34,6 +39,18 @@ var AllowedExtensions = map[string]bool{
 	".zip":  true,
 }
 
+// AllowedFarewellExtensions composes AllowedExtensions and adds audio/video formats.
+var AllowedFarewellExtensions = func() map[string]bool {
+	m := make(map[string]bool, len(AllowedExtensions)+9)
+	for k, v := range AllowedExtensions {
+		m[k] = v
+	}
+	for _, ext := range []string{".mp3", ".wav", ".ogg", ".m4a", ".aac", ".mp4", ".mov", ".webm", ".avi"} {
+		m[ext] = true
+	}
+	return m
+}()
+
 var AllowedMIMEPrefixes = []string{
 	"application/pdf",
 	"text/plain",
@@ -46,6 +63,14 @@ var AllowedMIMEPrefixes = []string{
 	"application/zip",
 	"application/octet-stream", // fallback for unknown binary types like .docx
 }
+
+// AllowedFarewellMIMEPrefixes composes AllowedMIMEPrefixes and adds audio/video MIME types.
+// application/ogg is explicit because http.DetectContentType returns it for .ogg files,
+// not the audio/ogg variant.
+var AllowedFarewellMIMEPrefixes = append(
+	append([]string{}, AllowedMIMEPrefixes...),
+	"audio/", "video/", "application/ogg",
+)
 
 var emailRegex = regexp.MustCompile(`^[a-zA-Z0-9.!#$%&'*+/=?^_` + "`" + `{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$`)
 
@@ -160,38 +185,57 @@ func (s ValidationService) ValidateTriggerDuration(duration int) error {
 	return nil
 }
 
-// ValidateFile validates a file upload: extension, MIME type, and size
-func (s ValidationService) ValidateFile(filename string, size int64, data []byte) error {
+type fileValidationOptions struct {
+	maxSize      int64
+	sizeErrMsg   string
+	extensions   map[string]bool
+	extErrMsg    string
+	mimePrefixes []string
+}
+
+func (s ValidationService) validateFileWith(filename string, size int64, data []byte, opts fileValidationOptions) error {
 	if size == 0 {
 		return BadRequest("File is empty", nil)
 	}
-	if size > MaxFileSize {
-		return BadRequest("File exceeds maximum size of 10 MB", nil)
+	if size > opts.maxSize {
+		return BadRequest(opts.sizeErrMsg, nil)
 	}
-
-	// Check extension
 	ext := strings.ToLower(filepath.Ext(filename))
 	if ext == "" {
 		return BadRequest("File must have an extension", nil)
 	}
-	if !AllowedExtensions[ext] {
-		return BadRequest("File type not allowed. Allowed: PDF, TXT, DOC, DOCX, JPG, PNG, GIF, WEBP, ZIP", nil)
+	if !opts.extensions[ext] {
+		return BadRequest(opts.extErrMsg, nil)
 	}
-
-	// Check MIME type via content sniffing (first 512 bytes)
 	detectedMIME := http.DetectContentType(data)
-	mimeAllowed := false
-	for _, prefix := range AllowedMIMEPrefixes {
+	for _, prefix := range opts.mimePrefixes {
 		if strings.HasPrefix(detectedMIME, prefix) {
-			mimeAllowed = true
-			break
+			return nil
 		}
 	}
-	if !mimeAllowed {
-		return BadRequest("File content type not allowed", nil)
-	}
+	return BadRequest("File content type not allowed", nil)
+}
 
-	return nil
+// ValidateFile validates a switch attachment: extension, MIME type, and size.
+func (s ValidationService) ValidateFile(filename string, size int64, data []byte) error {
+	return s.validateFileWith(filename, size, data, fileValidationOptions{
+		maxSize:      MaxFileSize,
+		sizeErrMsg:   "File exceeds maximum size of 10 MB",
+		extensions:   AllowedExtensions,
+		extErrMsg:    "File type not allowed. Allowed: PDF, TXT, DOC, DOCX, JPG, PNG, GIF, WEBP, ZIP",
+		mimePrefixes: AllowedMIMEPrefixes,
+	})
+}
+
+// ValidateFarewellFile validates a farewell letter attachment using provider-ceiling limits.
+func (s ValidationService) ValidateFarewellFile(filename string, size int64, data []byte) error {
+	return s.validateFileWith(filename, size, data, fileValidationOptions{
+		maxSize:      MaxFarewellFileSize,
+		sizeErrMsg:   "File exceeds maximum size of 20 MB",
+		extensions:   AllowedFarewellExtensions,
+		extErrMsg:    "File type not allowed. Allowed: PDF, TXT, DOC, DOCX, JPG, PNG, GIF, WEBP, ZIP, MP3, WAV, OGG, M4A, AAC, MP4, MOV, WEBM, AVI",
+		mimePrefixes: AllowedFarewellMIMEPrefixes,
+	})
 }
 
 // SanitizeFilename cleans a filename to prevent path traversal and other attacks

--- a/backend/internal/worker/worker.go
+++ b/backend/internal/worker/worker.go
@@ -9,26 +9,43 @@ import (
 
 	"github.com/alpyxn/aeterna/backend/internal/database"
 	"github.com/alpyxn/aeterna/backend/internal/models"
+	"github.com/alpyxn/aeterna/backend/internal/ports"
 	"github.com/alpyxn/aeterna/backend/internal/services"
 )
 
-var settingsService = services.SettingsService{}
-var emailService = services.EmailService{}
-var webhookService = services.WebhookService{}
-var webhookStore = services.WebhookStore{}
-var workerFileService = services.FileService{}
+// Worker runs the background goroutine that checks heartbeats, reminders, and farewell letters.
+type Worker struct {
+	settings ports.SettingsServicePort
+	webhooks ports.WebhookStorePort
+	files    ports.FileServicePort
+	email    services.EmailService
+	webhook  services.WebhookService
+}
 
-func Start() {
+func New(
+	settings ports.SettingsServicePort,
+	webhooks ports.WebhookStorePort,
+	files ports.FileServicePort,
+) *Worker {
+	return &Worker{
+		settings: settings,
+		webhooks: webhooks,
+		files:    files,
+	}
+}
+
+func (w *Worker) Start() {
 	ticker := time.NewTicker(1 * time.Minute)
 	defer ticker.Stop()
 
 	for range ticker.C {
-		checkReminders()
-		checkHeartbeats()
+		w.checkReminders()
+		w.checkHeartbeats()
+		w.checkFarewellLetters()
 	}
 }
 
-func checkReminders() {
+func (w *Worker) checkReminders() {
 	var reminders []models.MessageReminder
 
 	err := database.DB.Table("message_reminders").
@@ -52,15 +69,15 @@ func checkReminders() {
 		if msg.UserID == "" {
 			continue
 		}
-		settings, err := settingsService.Get(msg.UserID)
+		settings, err := w.settings.Get(msg.UserID)
 		if err != nil || settings.OwnerEmail == "" || settings.SMTPHost == "" {
 			continue
 		}
-		sendReminderEmail(settings, msg, req)
+		w.sendReminderEmail(settings, msg, req)
 	}
 }
 
-func sendReminderEmail(settings models.Settings, msg models.Message, reminder models.MessageReminder) {
+func (w *Worker) sendReminderEmail(settings models.Settings, msg models.Message, reminder models.MessageReminder) {
 	lastSeen := msg.LastSeen
 	triggerTime := lastSeen.Add(time.Duration(msg.TriggerDuration) * time.Minute)
 	remaining := time.Until(triggerTime)
@@ -92,17 +109,19 @@ To confirm you are available, click the link below:
 ---
 Sent by Aeterna`, remainingStr, formatRecipients(msg.RecipientEmail), quickLink)
 
-	err := emailService.SendPlain(settings, []string{settings.OwnerEmail}, subject, body)
+	err := w.email.SendPlain(settings, []string{settings.OwnerEmail}, subject, body)
 	if err != nil {
 		slog.Error("Failed to send reminder email", "error", err, "owner", settings.OwnerEmail)
 		return
 	}
 
-	database.DB.Model(&reminder).Update("sent", true)
+	if err := database.DB.Model(&reminder).Update("sent", true).Error; err != nil {
+		slog.Error("Failed to mark reminder as sent", "error", err, "reminder_id", reminder.ID)
+	}
 	slog.Info("Reminder email sent", "owner", settings.OwnerEmail, "message_id", msg.ID, "minutes_before", reminder.MinutesBefore)
 }
 
-func checkHeartbeats() {
+func (w *Worker) checkHeartbeats() {
 	var messages []models.Message
 
 	err := database.DB.Where(
@@ -118,26 +137,26 @@ func checkHeartbeats() {
 		if msg.UserID == "" {
 			continue
 		}
-		triggerSwitch(msg)
+		w.triggerSwitch(msg)
 	}
 }
 
-func triggerSwitch(msg models.Message) {
+func (w *Worker) triggerSwitch(msg models.Message) {
 	slog.Warn("Switch triggered", "recipient", formatRecipients(msg.RecipientEmail), "id", msg.ID)
 
-	settings, err := settingsService.Get(msg.UserID)
+	settings, err := w.settings.Get(msg.UserID)
 	if err != nil {
 		slog.Error("Failed to load SMTP settings", "error", err, "user_id", msg.UserID)
 		settings = models.Settings{}
 	}
 
 	var emailAttachments []services.EmailAttachment
-	attachments, err := workerFileService.ListByMessageID(msg.UserID, msg.ID)
+	attachments, err := w.files.ListByMessageID(msg.UserID, msg.ID)
 	if err != nil {
 		slog.Error("Failed to load attachments", "error", err, "message_id", msg.ID)
 	} else {
 		for _, att := range attachments {
-			filename, mimeType, data, err := workerFileService.GetDecrypted(msg.UserID, att.ID)
+			filename, mimeType, data, err := w.files.GetDecrypted(msg.UserID, att.ID)
 			if err != nil {
 				slog.Error("Failed to decrypt attachment", "error", err, "attachment_id", att.ID)
 				continue
@@ -151,7 +170,7 @@ func triggerSwitch(msg models.Message) {
 	}
 
 	if settings.SMTPHost != "" {
-		err := emailService.SendTriggeredMessage(settings, msg, emailAttachments)
+		err := w.email.SendTriggeredMessage(settings, msg, emailAttachments)
 		if err != nil {
 			slog.Error("Failed to send email", "error", err, "recipient", formatRecipients(msg.RecipientEmail))
 		} else {
@@ -161,23 +180,27 @@ func triggerSwitch(msg models.Message) {
 		slog.Info("Mock email", "recipient", formatRecipients(msg.RecipientEmail), "attachments", len(emailAttachments))
 	}
 
-	webhooks, err := webhookStore.ListEnabledForUser(msg.UserID)
+	webhooks, err := w.webhooks.ListEnabledForUser(msg.UserID)
 	if err != nil {
 		slog.Error("Failed to load webhooks", "error", err)
 	} else if len(webhooks) > 0 {
 		slog.Info("Webhook delivery attempt", "count", len(webhooks), "recipient", formatRecipients(msg.RecipientEmail))
-		if err := webhookService.SendTriggerWebhooks(webhooks, msg); err != nil {
+		if err := w.webhook.SendTriggerWebhooks(webhooks, msg); err != nil {
 			slog.Error("Failed to deliver webhook", "error", err, "recipient", formatRecipients(msg.RecipientEmail))
 		} else {
 			slog.Info("Webhook delivered", "count", len(webhooks), "recipient", formatRecipients(msg.RecipientEmail))
 		}
 	}
 
+	now := time.Now()
 	msg.Status = models.StatusTriggered
-	database.DB.Save(&msg)
+	msg.TriggeredAt = &now
+	if err := database.ForTenant(msg.UserID).Save(&msg).Error; err != nil {
+		slog.Error("Failed to persist triggered status", "error", err, "message_id", msg.ID)
+	}
 
 	if len(attachments) > 0 {
-		if err := workerFileService.DeleteByMessageID(msg.UserID, msg.ID); err != nil {
+		if err := w.files.DeleteByMessageID(msg.UserID, msg.ID); err != nil {
 			slog.Error("Failed to clean up attachments", "error", err, "message_id", msg.ID)
 		} else {
 			slog.Info("Attachments cleaned up", "message_id", msg.ID, "count", len(attachments))
@@ -185,16 +208,16 @@ func triggerSwitch(msg models.Message) {
 	}
 
 	if settings.OwnerEmail != "" && settings.SMTPHost != "" {
-		sendOwnerNotification(settings, msg, webhooks)
+		w.sendOwnerNotification(settings, msg, webhooks)
 	}
 }
 
-func sendOwnerNotification(settings models.Settings, msg models.Message, webhooks []models.Webhook) {
+func (w *Worker) sendOwnerNotification(settings models.Settings, msg models.Message, webhooks []models.Webhook) {
 	webhookInfo := ""
 	if len(webhooks) > 0 {
 		webhookInfo = "\n\nTriggered Webhooks:\n"
-		for _, w := range webhooks {
-			webhookInfo += fmt.Sprintf("- %s\n", w.URL)
+		for _, wh := range webhooks {
+			webhookInfo += fmt.Sprintf("- %s\n", wh.URL)
 		}
 	}
 
@@ -207,12 +230,92 @@ Recipient: %s%s
 
 Sent by Aeterna`, formatRecipients(msg.RecipientEmail), webhookInfo)
 
-	err := emailService.SendPlain(settings, []string{settings.OwnerEmail}, subject, body)
+	err := w.email.SendPlain(settings, []string{settings.OwnerEmail}, subject, body)
 	if err != nil {
 		slog.Error("Failed to send owner notification", "error", err, "owner", settings.OwnerEmail)
 	} else {
 		slog.Info("Owner notified of delivery", "owner", settings.OwnerEmail, "recipient", formatRecipients(msg.RecipientEmail))
 	}
+}
+
+func (w *Worker) checkFarewellLetters() {
+	var letters []models.FarewellLetter
+
+	err := database.DB.Table("farewell_letters").
+		Select("farewell_letters.*").
+		Joins("JOIN messages ON messages.id = farewell_letters.message_id").
+		Where("farewell_letters.status = ?", models.FarewellStatusPending).
+		Where("messages.status = ?", models.StatusTriggered).
+		Where("messages.triggered_at IS NOT NULL").
+		Where("datetime(messages.triggered_at, '+' || CAST(farewell_letters.delay_minutes AS TEXT) || ' minutes') <= datetime('now')").
+		Where("farewell_letters.deleted_at IS NULL").
+		Find(&letters).Error
+
+	if err != nil {
+		slog.Error("Error checking farewell letters", "error", err)
+		return
+	}
+
+	for _, letter := range letters {
+		if letter.UserID == "" {
+			continue
+		}
+		w.sendFarewellLetter(letter)
+	}
+}
+
+func (w *Worker) sendFarewellLetter(letter models.FarewellLetter) {
+	settings, err := w.settings.Get(letter.UserID)
+	if err != nil || settings.SMTPHost == "" {
+		slog.Error("SMTP not configured for farewell letter", "letter_id", letter.ID, "user_id", letter.UserID)
+		return
+	}
+
+	decrypted, err := services.CryptoService{}.Decrypt(letter.Content)
+	if err != nil {
+		slog.Error("Failed to decrypt farewell letter content", "letter_id", letter.ID, "error", err)
+		return
+	}
+
+	rawAttachments, err := w.files.ListFarewellAttachmentsByLetterID(letter.UserID, letter.ID)
+	if err != nil {
+		slog.Error("Failed to load farewell attachments", "letter_id", letter.ID, "error", err)
+	}
+
+	var emailAttachments []services.EmailAttachment
+	for _, att := range rawAttachments {
+		filename, mimeType, data, err := w.files.GetFarewellAttachmentDecrypted(letter.UserID, att.ID)
+		if err != nil {
+			slog.Error("Failed to decrypt farewell attachment", "attachment_id", att.ID, "error", err)
+			continue
+		}
+		emailAttachments = append(emailAttachments, services.EmailAttachment{
+			Filename: filename,
+			MimeType: mimeType,
+			Data:     data,
+		})
+	}
+
+	if err := w.email.SendFarewellLetter(settings, letter.RecipientEmail, letter.Subject, decrypted, emailAttachments); err != nil {
+		slog.Error("Failed to send farewell letter", "letter_id", letter.ID, "recipient", letter.RecipientEmail, "error", err)
+		return
+	}
+
+	now := time.Now()
+	if err := database.ForTenant(letter.UserID).Model(&letter).Updates(map[string]any{
+		"status":  models.FarewellStatusSent,
+		"sent_at": now,
+	}).Error; err != nil {
+		slog.Error("Failed to mark farewell letter as sent", "error", err, "letter_id", letter.ID)
+	}
+
+	if len(rawAttachments) > 0 {
+		if err := w.files.DeleteFarewellAttachmentsByLetterID(letter.UserID, letter.ID); err != nil {
+			slog.Error("Failed to clean up farewell attachments", "letter_id", letter.ID, "error", err)
+		}
+	}
+
+	slog.Info("Farewell letter sent", "letter_id", letter.ID, "recipient", letter.RecipientEmail)
 }
 
 func formatRecipients(value string) string {


### PR DESCRIPTION
## Description

This PR introduces the Farewell Letters feature together with a structural refactor of the backend. The changes fall into five areas: hexagonal architecture, worker refactor, cascade delete, email service deduplication, and comment cleanup. Each one is detailed below.

---

## 1. Hexagonal architecture (Ports & Adapters)

Before the refactor, handlers imported service structs directly, creating tight coupling:

```go
// before
func GetMessages(c *fiber.Ctx) error {
    svc := services.MessageService{}
    messages, err := svc.List(userID)
    ...
}
```

I added the `internal/ports/ports.go` package with interfaces that describe the contract of each service. Handlers now depend on the interface, not the implementation:

```go
// after
type MessageHandlers struct {
    messages ports.MessageServicePort
}

func NewMessageHandlers(messages ports.MessageServicePort) *MessageHandlers {
    return &MessageHandlers{messages: messages}
}
```

Go satisfies interfaces implicitly (duck typing), so `services.MessageService` implements `ports.MessageServicePort` without declaring it. The only place where implementations get wired to interfaces is `cmd/server/main.go`:

```go
messageSvc := services.MessageService{}
messageH   := handlers.NewMessageHandlers(messageSvc)
```

**Why it matters:** changing the signature of a port method produces a compile error in every caller, not a silent runtime bug. And when the time comes to write tests, handlers accept any implementation that satisfies the interface, with no real database needed.

While doing this I also found and fixed several direct accesses to `database.DB` that should have used `database.ForTenant(userID)`:

| File | Bug | Fix |
| --- | --- | --- |
| `worker.go` | `database.DB.Save(&msg)` | `database.ForTenant(msg.UserID).Save(&msg)` |
| `worker.go` | `database.DB.Model(&letter).Updates(...)` | `database.ForTenant(letter.UserID).Model(&letter).Updates(...)` |
| `farewell_service.go` | `database.DB.Save(&letter)` | `database.ForTenant(userID).Save(&letter)` |
| `farewell_service.go` | `database.DB.Unscoped().Delete(...)` | `database.ForTenant(userID).Unscoped().Delete(...)` |
| `message_service.go` | `database.DB.Unscoped().Delete(&msg)` | `database.ForTenant(userID).Unscoped().Delete(&msg)` |

---

## 2. Worker: from package-level functions to a struct with receiver `w`

The previous worker was a set of loose functions backed by global variables:

```go
// before
var settingsService = services.SettingsService{}
var webhookStore   = services.WebhookStore{}

func Start() { ... }
func checkHeartbeats() { ... } // what does it use? you have to read the whole body
```

It is now a struct with explicit dependencies:

```go
// after
type Worker struct {
    settings ports.SettingsServicePort
    webhooks ports.WebhookStorePort
    files    ports.FileServicePort
}

func New(settings ports.SettingsServicePort, webhooks ports.WebhookStorePort, files ports.FileServicePort) *Worker {
    return &Worker{settings: settings, webhooks: webhooks, files: files}
}

func (w *Worker) Start() {
    ticker := time.NewTicker(1 * time.Minute)
    defer ticker.Stop()
    for range ticker.C {
        w.checkReminders()
        w.checkHeartbeats()
        w.checkFarewellLetters()
    }
}
```

The signature of `New()` is the contract: *"to build a Worker I need these three services"*. No global state, no hidden dependencies.

About the `w` receiver: the Go convention is to use the lowercase initial of the type. `w` for `Worker`, `h` for `Handler`, `s` for `Service`. Not `self`, not `this`, not the full type name. The standard library is written this way throughout.

---

## 3. Cascade delete with GORM BeforeDelete hooks

SQLite's `OnDelete:CASCADE` only works with hard deletes. The project uses soft delete (`DeletedAt`) on most models, so the native cascade does not apply.

I added `BeforeDelete` hooks on `Message` and `FarewellLetter` that inspect `tx.Statement.Unscoped` to propagate the same mode (soft or hard) to the child records:

```go
func (m *Message) BeforeDelete(tx *gorm.DB) error {
    if m.ID == "" {
        return nil // batch context: the parent hook already handles the cascade
    }
    db := tx
    if tx.Statement.Unscoped {
        db = tx.Unscoped()
    }
    var letterIDs []string
    db.Model(&FarewellLetter{}).Select("id").Where("message_id = ?", m.ID).Find(&letterIDs)
    if len(letterIDs) == 0 {
        return nil
    }
    if err := db.Where("letter_id IN ?", letterIDs).Delete(&FarewellAttachment{}).Error; err != nil {
        return err
    }
    return db.Where("id IN ?", letterIDs).Delete(&FarewellLetter{}).Error
}
```

The responsibilities are split on purpose: the hook only deals with DB records, and the service layer cleans up the filesystem before calling the delete (the hook has no access to file paths).

---

## 4. EmailService: extracting `sendRaw`

The SMTP port detection + retry block was duplicated across `SendPlain`, `SendWithAttachments`, and `SendFarewellLetter`:

```go
// before, repeated in all three methods
addr := settings.SMTPHost + ":" + settings.SMTPPort
if settings.SMTPPort == "465" {
    return s.sendWithRetry(func() error {
        return s.sendEmailSSL(settings, addr, from, recipients, message)
    })
}
return s.sendWithRetry(func() error {
    return s.sendEmailSTARTTLS(settings, addr, from, recipients, message)
})
```

I extracted a private `sendRaw` method, and all three callers now end with:

```go
return s.sendRaw(settings, from, recipients, message)
```

If support for port 587 is added later, or the SMTP dispatch changes, only one place has to change.

---

## 5. Comment cleanup

I removed comments that just restated the name of the symbol they sat above:

```go
// before
// AuthHandlers handles authentication-related HTTP requests
type AuthHandlers struct { ... }

// NewAuthHandlers creates a new AuthHandlers instance
func NewAuthHandlers(auth ports.AuthServicePort) *AuthHandlers { ... }

// Login handles user login requests
func (h *AuthHandlers) Login(c *fiber.Ctx) error { ... }

// after, no redundant comments
type AuthHandlers struct { ... }
func NewAuthHandlers(auth ports.AuthServicePort) *AuthHandlers { ... }
func (h *AuthHandlers) Login(c *fiber.Ctx) error { ... }
```

The comments that stayed are the ones that explain something the code itself cannot, such as security constraints or non-obvious behavior:

```go
// Sanitize headers to prevent header injection
from = sanitizeEmailHeader(from)

// application/ogg is explicit because http.DetectContentType returns it for .ogg files,
// not the audio/ogg variant.
```

A comment that repeats the function name gives the reader nothing, and when the code changes it can fall out of sync without anyone noticing.


# Commit Message Text (Conventional Commit):

New feature: farewell letters — personal delayed emails tied to a switch trigger. Users can write multiple farewell letters per switch, each with an independent delay, recipient, subject, Markdown body, and up to 10 attachments (audio, video, images; 20 MB/file, 50 MB total). The worker sends them once triggered_at + delay_minutes <= now.

New files:
- internal/models/farewell_letter.go
- internal/models/farewell_attachment.go
- internal/services/farewell_service.go
- internal/handlers/farewell_handler.go
- internal/ports/ports.go

Architectural refactor (Ports & Adapters):
- Introduce internal/ports/ports.go with service interfaces
- Refactor all handlers to structs with constructor DI (NewXHandlers)
- Refactor Worker to struct with explicit dependencies (worker.New)
- Composition root wired exclusively in cmd/server/main.go

Email service:
- Extract sendRaw private method; eliminate SMTP dispatch duplication across SendPlain, SendWithAttachments, and SendFarewellLetter
- Add SendFarewellLetter with HTML/Markdown rendering (gomarkdown)

Models:
- Message.BeforeDelete: cascade soft/hard delete to FarewellLetters and FarewellAttachments
- FarewellLetter.BeforeDelete: cascade to FarewellAttachments on single-letter deletes
- Message: add TriggeredAt field for farewell letter scheduling
- User: add UserListItem (moved from services)

Validation:
- Extract validateFileWith helper; eliminate duplication between ValidateFile and ValidateFarewellFile
- Compose AllowedFarewellExtensions and AllowedFarewellMIMEPrefixes from base lists; add audio/video types
- Fix: add "application/ogg" explicitly — http.DetectContentType returns application/ogg for .ogg files, not audio/ogg

Bug fixes:
- worker: handle errors on DB Save/Update (silent failure could cause duplicate email sends on next tick)
- worker: fix database.DB.Save/Update without tenant scope → ForTenant
- farewell_service: fix database.DB.Save/Delete → ForTenant
- message_service: fix database.DB.Unscoped().Delete → ForTenant
- user_admin_service: log errors on farewell attachment cleanup (previously _ = silently left orphaned files on disk)

Other:
- Raise body limit from 12 MB to 25 MB for farewell attachments
- ApplicationSettingsService: add CanManageRegistration
- MessageService: add BulkHeartbeat for quick-heartbeat handler
- Remove comments that only repeat the symbol name