### PR TITLE
fix(farewell): preserve zero-delay letters and improve save UX

### DIFF
--- a/backend/internal/handlers/farewell_handler.go
+++ b/backend/internal/handlers/farewell_handler.go
@@ -14,6 +14,24 @@ type FarewellHandlers struct {
 	files    ports.FileServicePort
 }
 
+type farewellPayload struct {
+	RecipientEmail string `json:"recipient_email"`
+	Subject        string `json:"subject"`
+	Content        string `json:"content"`
+	DelayMinutes   *int   `json:"delay_minutes"`
+}
+
+func parseFarewellPayload(c *fiber.Ctx) (farewellPayload, error) {
+	var body farewellPayload
+	if err := c.BodyParser(&body); err != nil {
+		return farewellPayload{}, services.BadRequest("Invalid request body", err)
+	}
+	if body.DelayMinutes == nil {
+		return farewellPayload{}, services.BadRequest("delay_minutes is required and must be a number", nil)
+	}
+	return body, nil
+}
+
 func NewFarewellHandlers(farewell ports.FarewellServicePort, files ports.FileServicePort) *FarewellHandlers {
 	return &FarewellHandlers{farewell: farewell, files: files}
 }
@@ -40,17 +58,19 @@ func (h *FarewellHandlers) Create(c *fiber.Ctx) error {
 	}
 	messageID := c.Params("id")
 
-	var body struct {
-		RecipientEmail string `json:"recipient_email"`
-		Subject        string `json:"subject"`
-		Content        string `json:"content"`
-		DelayMinutes   int    `json:"delay_minutes"`
-	}
-	if err := c.BodyParser(&body); err != nil {
-		return writeError(c, services.BadRequest("Invalid request body", err))
+	body, err := parseFarewellPayload(c)
+	if err != nil {
+		return writeError(c, err)
 	}
 
-	letter, err := h.farewell.Create(userID, messageID, body.RecipientEmail, body.Subject, body.Content, body.DelayMinutes)
+	letter, err := h.farewell.Create(
+		userID,
+		messageID,
+		body.RecipientEmail,
+		body.Subject,
+		body.Content,
+		*body.DelayMinutes,
+	)
 	if err != nil {
 		return writeError(c, err)
 	}
@@ -66,17 +86,20 @@ func (h *FarewellHandlers) Update(c *fiber.Ctx) error {
 	messageID := c.Params("id")
 	letterID := c.Params("letterId")
 
-	var body struct {
-		RecipientEmail string `json:"recipient_email"`
-		Subject        string `json:"subject"`
-		Content        string `json:"content"`
-		DelayMinutes   int    `json:"delay_minutes"`
-	}
-	if err := c.BodyParser(&body); err != nil {
-		return writeError(c, services.BadRequest("Invalid request body", err))
+	body, err := parseFarewellPayload(c)
+	if err != nil {
+		return writeError(c, err)
 	}
 
-	letter, err := h.farewell.Update(userID, messageID, letterID, body.RecipientEmail, body.Subject, body.Content, body.DelayMinutes)
+	letter, err := h.farewell.Update(
+		userID,
+		messageID,
+		letterID,
+		body.RecipientEmail,
+		body.Subject,
+		body.Content,
+		*body.DelayMinutes,
+	)
 	if err != nil {
 		return writeError(c, err)
 	}

--- a/backend/internal/models/farewell_letter.go
+++ b/backend/internal/models/farewell_letter.go
@@ -21,7 +21,7 @@ type FarewellLetter struct {
 	RecipientEmail  string               `gorm:"not null" json:"recipient_email"`
 	Subject         string               `gorm:"not null" json:"subject"`
 	Content         string               `gorm:"column:encrypted_content;not null" json:"content"`
-	DelayMinutes    int                  `gorm:"not null;default:1440" json:"delay_minutes"`
+	DelayMinutes    int                  `gorm:"not null" json:"delay_minutes"`
 	Status          FarewellLetterStatus `gorm:"default:'pending'" json:"status"`
 	SentAt          *time.Time           `json:"sent_at,omitempty"`
 	AttachmentCount int64                `gorm:"-" json:"attachment_count"`
@@ -40,13 +40,16 @@ func (f *FarewellLetter) BeforeCreate(tx *gorm.DB) error {
 // BeforeDelete cascades the delete to associated FarewellAttachments,
 // mirroring the soft/hard mode of the parent operation.
 // When called from a batch context (f.ID == ""), the parent Message.BeforeDelete handles it.
+//
+// Uses a fresh session so the parent statement's Where/Select clauses don't leak
+// into the cascade query.
 func (f *FarewellLetter) BeforeDelete(tx *gorm.DB) error {
 	if f.ID == "" {
 		return nil
 	}
-	db := tx
+	sess := tx.Session(&gorm.Session{NewDB: true})
 	if tx.Statement.Unscoped {
-		db = tx.Unscoped()
+		sess = sess.Unscoped()
 	}
-	return db.Where("letter_id = ?", f.ID).Delete(&FarewellAttachment{}).Error
+	return sess.Where("letter_id = ?", f.ID).Delete(&FarewellAttachment{}).Error
 }

--- a/backend/internal/models/message.go
+++ b/backend/internal/models/message.go
@@ -45,23 +45,31 @@ func (m *Message) BeforeCreate(tx *gorm.DB) error {
 
 // BeforeDelete cascades the delete to associated FarewellLetters and their attachments,
 // mirroring the soft/hard mode of the parent operation.
+//
+// Each query opens a fresh session so chain conditions (Where, Select, Model) don't
+// leak between operations on the same underlying gorm.DB.
 func (m *Message) BeforeDelete(tx *gorm.DB) error {
 	if m.ID == "" {
 		return nil
 	}
-	db := tx
-	if tx.Statement.Unscoped {
-		db = tx.Unscoped()
+	unscoped := tx.Statement.Unscoped
+	newSession := func() *gorm.DB {
+		s := tx.Session(&gorm.Session{NewDB: true})
+		if unscoped {
+			s = s.Unscoped()
+		}
+		return s
 	}
+
 	var letterIDs []string
-	if err := db.Model(&FarewellLetter{}).Select("id").Where("message_id = ?", m.ID).Find(&letterIDs).Error; err != nil {
+	if err := newSession().Model(&FarewellLetter{}).Select("id").Where("message_id = ?", m.ID).Find(&letterIDs).Error; err != nil {
 		return err
 	}
 	if len(letterIDs) == 0 {
 		return nil
 	}
-	if err := db.Where("letter_id IN ?", letterIDs).Delete(&FarewellAttachment{}).Error; err != nil {
+	if err := newSession().Where("letter_id IN ?", letterIDs).Delete(&FarewellAttachment{}).Error; err != nil {
 		return err
 	}
-	return db.Where("id IN ?", letterIDs).Delete(&FarewellLetter{}).Error
+	return newSession().Where("id IN ?", letterIDs).Delete(&FarewellLetter{}).Error
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,9 @@
       "dependencies": {
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "dompurify": "^3.3.0",
         "lucide-react": "^0.563.0",
+        "marked": "^18.0.3",
         "radix-ui": "^1.4.3",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -28,7 +30,7 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
-        "postcss": "^8.5.6",
+        "postcss": "8.5.10",
         "tailwindcss": "^4.1.18",
         "tw-animate-css": "^1.4.0",
         "vite": "^7.3.2"
@@ -3400,6 +3402,13 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@vitejs/plugin-react-swc": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-4.2.3.tgz",
@@ -3756,6 +3765,15 @@
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.283",
@@ -4706,6 +4724,18 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/marked": {
+      "version": "18.0.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.3.tgz",
+      "integrity": "sha512-7VT90JOkDeaRWpfjOReRGPEKn0ecdARBkDGL+tT1wZY0efPPqkUxLUSmzy/C7TIylQYJC9STISEsCHrqb/7VIA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -4863,9 +4893,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,9 @@
   "dependencies": {
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "dompurify": "^3.3.0",
     "lucide-react": "^0.563.0",
+    "marked": "^18.0.3",
     "radix-ui": "^1.4.3",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
@@ -30,7 +32,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
-    "postcss": "^8.5.6",
+    "postcss": "8.5.10",
     "tailwindcss": "^4.1.18",
     "tw-animate-css": "^1.4.0",
     "vite": "^7.3.2"

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -23,8 +23,9 @@ function App() {
     checkSession();
   }, []);
 
-  const handleUnlock = () => {
+  const handleUnlock = (target = 'dashboard') => {
     setAuthorized(true);
+    setRoute(target);
   };
 
   const handleLogout = async () => {

--- a/frontend/src/components/CreateSwitch.jsx
+++ b/frontend/src/components/CreateSwitch.jsx
@@ -4,52 +4,15 @@ import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from "@/components/ui/card"
 import { Alert, AlertDescription } from "@/components/ui/alert"
-import { Lock, Mail, Clock, Loader2, AlertCircle, CheckCircle, Send, Paperclip, X, Upload, Settings as SettingsIcon, Plus } from 'lucide-react';
+import { Lock, Mail, Clock, Loader2, AlertCircle, CheckCircle, Send, Paperclip, X, Upload, Settings as SettingsIcon, Plus, ArrowRight, MessageSquare, Pencil } from 'lucide-react';
 import { Select } from "@/components/ui/select"
-import { apiRequest, uploadFile } from "@/lib/api"
+import { apiRequest, uploadFile, createFarewellLetter, uploadFarewellAttachment } from "@/lib/api"
+import FarewellLetters from "@/components/FarewellLetters"
+import { ALLOWED_EXTENSIONS, MAX_FILE_SIZE, MAX_FILES, MAX_TOTAL_SIZE, EMAIL_REGEX, TIME_PRESETS, REMINDER_PRESETS, FAREWELL_DELAY_PRESETS } from "@/lib/constants"
+import { formatFileSize, formatMinutes, formatFarewellDelay } from "@/lib/formatters"
+import { parseRecipientEmails } from "@/lib/parsers"
+import { applyDurationToReminders, addReminderValue, removeReminderValue } from "@/lib/reminder-utils"
 
-const ALLOWED_EXTENSIONS = ['.pdf', '.txt', '.doc', '.docx', '.jpg', '.jpeg', '.png', '.gif', '.webp', '.zip'];
-const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
-const MAX_FILES = 5;
-const MAX_TOTAL_SIZE = 25 * 1024 * 1024; // 25 MB
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-
-function parseRecipientEmails(input) {
-    const parts = input
-        .split(/[\n,;]+/)
-        .map((value) => value.trim())
-        .filter(Boolean);
-
-    const unique = [];
-    const seen = new Set();
-    for (const email of parts) {
-        const key = email.toLowerCase();
-        if (!seen.has(key)) {
-            seen.add(key);
-            unique.push(email);
-        }
-    }
-    return unique;
-}
-
-function formatFileSize(bytes) {
-    if (bytes < 1024) return bytes + ' B';
-    if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
-    return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
-}
-
-function formatMinutes(minutes) {
-    if (minutes >= 1440) {
-        // e.g., 2880 -> 2, 3600 -> 2.5
-        const days = Number((minutes / 1440).toFixed(1));
-        return `${days} Day${days !== 1 ? 's' : ''} Before`;
-    }
-    if (minutes >= 60) {
-        const hours = Number((minutes / 60).toFixed(1));
-        return `${hours} Hour${hours !== 1 ? 's' : ''} Before`;
-    }
-    return `${minutes} Minutes Before`;
-}
 
 export default function CreateSwitch({ setRoute }) {
     const [message, setMessage] = useState('');
@@ -65,58 +28,88 @@ export default function CreateSwitch({ setRoute }) {
     const [showAttachments, setShowAttachments] = useState(false);
     const [dragOver, setDragOver] = useState(false);
     const [smtpError, setSmtpError] = useState(false);
+    const [createdMessageId, setCreatedMessageId] = useState(null);
+    const [pendingLetters, setPendingLetters] = useState([]);
+    const [showLetterForm, setShowLetterForm] = useState(false);
+    const [editingLetterIdx, setEditingLetterIdx] = useState(null);
+    const [letterRecipient, setLetterRecipient] = useState('');
+    const [letterSubject, setLetterSubject] = useState('');
+    const [letterContent, setLetterContent] = useState('');
+    const [letterDelay, setLetterDelay] = useState(1440);
+    const [letterFormError, setLetterFormError] = useState(null);
+    const [letterFiles, setLetterFiles] = useState([]);
     const fileInputRef = useRef(null);
 
-    const timePresets = [
-        { label: '1 Minute (Debug)', value: 1 },
-        { label: '15 Minutes (Test)', value: 15 },
-        { label: '1 Hour', value: 60 },
-        { label: '1 Day', value: 1440 },
-        { label: '3 Days', value: 4320 },
-        { label: '1 Week', value: 10080 },
-        { label: '2 Weeks', value: 20160 },
-        { label: '1 Month', value: 43200 },
-        { label: '3 Months', value: 129600 },
-        { label: '6 Months', value: 259200 },
-        { label: '1 Year', value: 525600 },
-    ];
+    const resetLetterForm = () => {
+        setLetterRecipient('');
+        setLetterSubject('');
+        setLetterContent('');
+        setLetterDelay(1440);
+        setLetterFiles([]);
+        setEditingLetterIdx(null);
+        setShowLetterForm(false);
+        setLetterFormError(null);
+    };
 
-    const reminderPresets = [
-        { label: '15 Minutes Before', value: 15 },
-        { label: '1 Hour Before', value: 60 },
-        { label: '12 Hours Before', value: 720 },
-        { label: '1 Day Before', value: 1440 },
-        { label: '2 Days Before', value: 2880 },
-        { label: '3 Days Before', value: 4320 },
-        { label: '5 Days Before', value: 7200 },
-        { label: '10 Days Before', value: 14400 },
-    ];
+    const savePendingLetter = () => {
+        const recipient = letterRecipient.trim();
+        const subject = letterSubject.trim();
+        const content = letterContent;
+        if (!EMAIL_REGEX.test(recipient)) {
+            setLetterFormError('Enter a valid recipient email.');
+            return;
+        }
+        if (!subject) {
+            setLetterFormError('Subject is required.');
+            return;
+        }
+        if (!content.trim()) {
+            setLetterFormError('Letter content cannot be empty.');
+            return;
+        }
+        const payload = {
+            recipient_email: recipient,
+            subject,
+            content,
+            delay_minutes: letterDelay,
+            files: letterFiles,
+        };
+        if (editingLetterIdx != null) {
+            setPendingLetters(prev => prev.map((l, i) => i === editingLetterIdx ? { ...l, ...payload } : l));
+        } else {
+            setPendingLetters(prev => [...prev, payload]);
+        }
+        resetLetterForm();
+    };
+
+    const editPendingLetter = (idx) => {
+        const l = pendingLetters[idx];
+        setLetterRecipient(l.recipient_email);
+        setLetterSubject(l.subject);
+        setLetterContent(l.content);
+        setLetterDelay(l.delay_minutes);
+        setLetterFiles(l.files || []);
+        setEditingLetterIdx(idx);
+        setShowLetterForm(true);
+        setLetterFormError(null);
+    };
+
+    const removePendingLetter = (idx) => {
+        setPendingLetters(prev => prev.filter((_, i) => i !== idx));
+    };
+
 
     const handleDurationChange = (newDuration) => {
         setDuration(newDuration);
-        // Add sensible default reminders if none are valid for the new duration
-        const validReminders = reminders.filter(r => r < newDuration);
-        if (validReminders.length === 0) {
-            if (newDuration >= 1440) { // >= 1 day
-                setReminders([newDuration / 2]); // 50%
-            } else if (newDuration >= 60) { // >= 1 hour
-                setReminders([15]); // 15 mins
-            } else {
-                setReminders([]);
-            }
-        } else {
-            setReminders(validReminders);
-        }
+        setReminders((prev) => applyDurationToReminders(prev, newDuration));
     };
 
     const addReminder = (value) => {
-        if (!reminders.includes(value) && value < duration) {
-            setReminders([...reminders, value].sort((a, b) => b - a)); // sort descending (longest before trigger first)
-        }
+        setReminders((prev) => addReminderValue(prev, value, duration));
     };
 
     const removeReminder = (value) => {
-        setReminders(reminders.filter(r => r !== value));
+        setReminders((prev) => removeReminderValue(prev, value));
     };
 
     const validateFile = (file) => {
@@ -320,14 +313,38 @@ export default function CreateSwitch({ setRoute }) {
                 }
             }
 
-            setSuccess(true);
+            // Step 3: Create pending farewell letters (if any)
+            const letterErrors = [];
+            for (let i = 0; i < pendingLetters.length; i++) {
+                const letterData = pendingLetters[i];
+                setUploadProgress(`Creating farewell letter ${i + 1}/${pendingLetters.length}...`);
+                try {
+                    const savedLetter = await createFarewellLetter(result.id, {
+                        recipient_email: letterData.recipient_email,
+                        subject: letterData.subject,
+                        content: letterData.content,
+                        delay_minutes: letterData.delay_minutes,
+                    });
+                    for (const file of letterData.files || []) {
+                        setUploadProgress(`Uploading attachment for "${letterData.subject}"...`);
+                        await uploadFarewellAttachment(result.id, savedLetter.id, file);
+                    }
+                } catch (letterErr) {
+                    letterErrors.push(`"${letterData.subject}": ${letterErr.message}`);
+                }
+            }
+
             setMessage('');
             setRecipientInput('');
             setRecipientEmails([]);
             setFiles([]);
+            setPendingLetters([]);
+            resetLetterForm();
             setUploadProgress('');
-
-            setTimeout(() => setSuccess(false), 5000);
+            setCreatedMessageId(result.id);
+            if (letterErrors.length > 0) {
+                setError(`Switch created, but ${letterErrors.length} farewell letter(s) failed: ${letterErrors.join('; ')}`);
+            }
         } catch (e) {
             setError(e.message);
         } finally {
@@ -335,6 +352,48 @@ export default function CreateSwitch({ setRoute }) {
             setUploadProgress('');
         }
     };
+
+    if (createdMessageId) {
+        return (
+            <div className="w-full max-w-2xl space-y-6">
+                <div className="text-center space-y-2">
+                    <h1 className="text-2xl font-semibold text-dark-100">Switch activated</h1>
+                    <p className="text-dark-400 text-sm max-w-md mx-auto">
+                        Optionally add farewell letters that will be sent after this switch fires.
+                    </p>
+                </div>
+
+                <Alert className="border-teal-500/20 bg-teal-500/10">
+                    <CheckCircle className="h-4 w-4 text-teal-400" />
+                    <AlertDescription className="text-teal-400">
+                        Switch created. Remember to check in regularly from the Dashboard.
+                    </AlertDescription>
+                </Alert>
+
+                <Card className="glowing-card">
+                    <CardContent className="pt-6">
+                        <FarewellLetters messageId={createdMessageId} />
+                    </CardContent>
+                </Card>
+
+                <div className="flex flex-col sm:flex-row gap-2 justify-end">
+                    <Button
+                        variant="outline"
+                        onClick={() => setCreatedMessageId(null)}
+                        className="border-dark-700 bg-dark-900 hover:bg-dark-800 text-dark-200"
+                    >
+                        <Plus className="w-4 h-4 mr-2" /> Create another switch
+                    </Button>
+                    <Button
+                        onClick={() => setRoute?.('dashboard')}
+                        className="bg-teal-600 hover:bg-teal-500 text-white"
+                    >
+                        Go to Dashboard <ArrowRight className="w-4 h-4 ml-2" />
+                    </Button>
+                </div>
+            </div>
+        );
+    }
 
     return (
         <div className="w-full max-w-2xl space-y-6">
@@ -522,7 +581,7 @@ export default function CreateSwitch({ setRoute }) {
                                 onChange={(e) => handleDurationChange(Number(e.target.value))}
                                 className="bg-dark-950 border-dark-700 text-dark-100"
                             >
-                                {timePresets.map(preset => (
+                                {TIME_PRESETS.map(preset => (
                                     <option key={preset.value} value={preset.value}>
                                         {preset.label}
                                     </option>
@@ -539,12 +598,12 @@ export default function CreateSwitch({ setRoute }) {
                             {reminders.length > 0 ? (
                                 <div className="flex flex-wrap gap-2">
                                     {reminders.map(r => {
-                                        const preset = reminderPresets.find(p => p.value === r);
+                                        const preset = REMINDER_PRESETS.find(p => p.value === r);
                                         const label = preset ? preset.label : formatMinutes(r);
                                         return (
                                             <div key={r} className="flex items-center gap-1 bg-dark-800 text-dark-200 text-xs px-2 py-1 rounded">
                                                 <span>{label}</span>
-                                                <button onClick={() => removeReminder(r)} className="text-dark-400 hover:text-red-400">
+                                                <button type="button" onClick={() => removeReminder(r)} className="text-dark-400 hover:text-red-400">
                                                     <X className="w-3 h-3" />
                                                 </button>
                                             </div>
@@ -567,7 +626,7 @@ export default function CreateSwitch({ setRoute }) {
                                     value={""}
                                 >
                                     <option value="" disabled>Add a reminder...</option>
-                                    {reminderPresets.filter(p => !reminders.includes(p.value) && p.value < duration).map(preset => (
+                                    {REMINDER_PRESETS.filter(p => !reminders.includes(p.value) && p.value < duration).map(preset => (
                                         <option key={preset.value} value={preset.value}>
                                             {preset.label}
                                         </option>
@@ -575,6 +634,179 @@ export default function CreateSwitch({ setRoute }) {
                                 </Select>
                             </div>
                         </div>
+                    </div>
+
+                    {/* Farewell Letters */}
+                    <div className="space-y-2">
+                        <div className="flex items-center justify-between">
+                            <label className="text-xs font-medium text-dark-400 flex items-center gap-2">
+                                <MessageSquare className="w-3 h-3" /> Farewell Letters
+                                <span className="text-dark-600 font-normal">(optional)</span>
+                            </label>
+                            {!showLetterForm && (
+                                <Button
+                                    type="button"
+                                    size="sm"
+                                    variant="outline"
+                                    onClick={() => { setShowLetterForm(true); setEditingLetterIdx(null); }}
+                                    className="border-dark-700 bg-dark-900 hover:bg-dark-800 text-dark-200 h-7 text-xs"
+                                >
+                                    <Plus className="w-3 h-3 mr-1" /> Add letter
+                                </Button>
+                            )}
+                        </div>
+
+                        {showLetterForm && (
+                            <div className="space-y-3 p-3 border border-dark-700 rounded-lg bg-dark-900">
+                                {letterFormError && (
+                                    <p className="text-xs text-red-400">{letterFormError}</p>
+                                )}
+                                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                                    <div className="space-y-1">
+                                        <label className="text-xs font-medium text-dark-400 flex items-center gap-1">
+                                            <Mail className="w-3 h-3" /> Recipient email
+                                        </label>
+                                        <Input
+                                            type="email"
+                                            placeholder="someone@example.com"
+                                            value={letterRecipient}
+                                            onChange={(e) => setLetterRecipient(e.target.value)}
+                                            className="bg-dark-950 border-dark-700 focus:border-teal-500 text-dark-100 placeholder:text-dark-500"
+                                        />
+                                    </div>
+                                    <div className="space-y-1">
+                                        <label className="text-xs font-medium text-dark-400 flex items-center gap-1">
+                                            <Clock className="w-3 h-3" /> Send delay
+                                        </label>
+                                        <select
+                                            value={letterDelay}
+                                            onChange={(e) => setLetterDelay(Number(e.target.value))}
+                                            className="w-full h-9 rounded-md border border-dark-700 bg-dark-950 text-dark-100 text-sm px-3 focus:outline-none focus:border-teal-500"
+                                        >
+                                            {FAREWELL_DELAY_PRESETS.map(p => (
+                                                <option key={p.value} value={p.value}>{p.label}</option>
+                                            ))}
+                                        </select>
+                                    </div>
+                                </div>
+                                <div className="space-y-1">
+                                    <label className="text-xs font-medium text-dark-400">Subject</label>
+                                    <Input
+                                        type="text"
+                                        placeholder="A farewell message for you"
+                                        value={letterSubject}
+                                        onChange={(e) => setLetterSubject(e.target.value)}
+                                        className="bg-dark-950 border-dark-700 focus:border-teal-500 text-dark-100 placeholder:text-dark-500"
+                                    />
+                                </div>
+                                <div className="space-y-1">
+                                    <label className="text-xs font-medium text-dark-400">Message</label>
+                                    <Textarea
+                                        placeholder="Write your farewell message..."
+                                        value={letterContent}
+                                        onChange={(e) => setLetterContent(e.target.value)}
+                                        className="min-h-[100px] bg-dark-950 border-dark-700 focus:border-teal-500 text-dark-100 placeholder:text-dark-500"
+                                    />
+                                </div>
+                                <div className="space-y-1">
+                                    <div className="flex items-center justify-between">
+                                        <label className="text-xs font-medium text-dark-400 flex items-center gap-1">
+                                            <Paperclip className="w-3 h-3" /> Attachments
+                                            <span className="text-dark-600 font-normal">({letterFiles.length}/{MAX_FILES})</span>
+                                        </label>
+                                        {letterFiles.length < MAX_FILES && (
+                                            <label className="cursor-pointer flex items-center gap-1 text-xs text-teal-400 hover:text-teal-300">
+                                                <Upload className="w-3 h-3" /> Add file
+                                                <input
+                                                    type="file"
+                                                    className="hidden"
+                                                    accept={ALLOWED_EXTENSIONS.join(',')}
+                                                    onChange={(e) => {
+                                                        const file = e.target.files?.[0];
+                                                        if (!file) return;
+                                                        const err = validateFile(file);
+                                                        if (err) { setLetterFormError(err); e.target.value = ''; return; }
+                                                        const totalSize = letterFiles.reduce((s, f) => s + f.size, 0);
+                                                        if (totalSize + file.size > MAX_TOTAL_SIZE) {
+                                                            setLetterFormError('Total attachment size would exceed 25 MB');
+                                                            e.target.value = '';
+                                                            return;
+                                                        }
+                                                        setLetterFiles(prev => [...prev, file]);
+                                                        e.target.value = '';
+                                                    }}
+                                                />
+                                            </label>
+                                        )}
+                                    </div>
+                                    {letterFiles.length > 0 && (
+                                        <div className="space-y-1">
+                                            {letterFiles.map((file, idx) => (
+                                                <div key={`${file.name}-${idx}`} className="flex items-center justify-between bg-dark-900 border border-dark-700 rounded px-2 py-1.5">
+                                                    <div className="flex items-center gap-2 min-w-0">
+                                                        <Paperclip className="w-3 h-3 text-dark-400 shrink-0" />
+                                                        <span className="text-xs text-dark-200 truncate">{file.name}</span>
+                                                        <span className="text-xs text-dark-500 shrink-0">{formatFileSize(file.size)}</span>
+                                                    </div>
+                                                    <button
+                                                        type="button"
+                                                        onClick={() => setLetterFiles(prev => prev.filter((_, i) => i !== idx))}
+                                                        className="text-dark-500 hover:text-red-400 ml-2"
+                                                    >
+                                                        <X className="w-3 h-3" />
+                                                    </button>
+                                                </div>
+                                            ))}
+                                        </div>
+                                    )}
+                                </div>
+                                <div className="flex gap-2 justify-end">
+                                    <Button
+                                        type="button"
+                                        size="sm"
+                                        variant="outline"
+                                        onClick={resetLetterForm}
+                                        className="border-dark-700 bg-dark-900 hover:bg-dark-800 text-dark-200"
+                                    >
+                                        Cancel
+                                    </Button>
+                                    <Button
+                                        type="button"
+                                        size="sm"
+                                        onClick={savePendingLetter}
+                                        className="bg-teal-600 hover:bg-teal-500 text-white"
+                                    >
+                                        {editingLetterIdx != null ? 'Update letter' : 'Add letter'}
+                                    </Button>
+                                </div>
+                            </div>
+                        )}
+
+                        {pendingLetters.length > 0 && (
+                            <div className="space-y-1.5">
+                                {pendingLetters.map((letter, idx) => (
+                                    <div key={idx} className="flex items-start justify-between gap-3 p-3 border border-dark-700 rounded-lg bg-dark-900">
+                                        <div className="min-w-0 flex-1 space-y-1">
+                                            <span className="text-xs font-medium text-dark-100 truncate block">{letter.subject}</span>
+                                            <div className="flex items-center gap-3 text-xs text-dark-400">
+                                                <span className="flex items-center gap-1"><Mail className="w-3 h-3" />{letter.recipient_email}</span>
+                                                <span className="flex items-center gap-1"><Clock className="w-3 h-3" />{formatFarewellDelay(letter.delay_minutes)}</span>
+                                            </div>
+                                        </div>
+                                        <div className="flex items-center gap-1 shrink-0">
+                                            <Button size="sm" variant="ghost" onClick={() => editPendingLetter(idx)}
+                                                className="h-7 w-7 p-0 text-dark-400 hover:text-dark-100 hover:bg-dark-800">
+                                                <Pencil className="w-3 h-3" />
+                                            </Button>
+                                            <Button size="sm" variant="ghost" onClick={() => removePendingLetter(idx)}
+                                                className="h-7 w-7 p-0 text-dark-400 hover:text-red-400 hover:bg-red-950/30">
+                                                <X className="w-3 h-3" />
+                                            </Button>
+                                        </div>
+                                    </div>
+                                ))}
+                            </div>
+                        )}
                     </div>
 
                     {error && (

--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -6,57 +6,19 @@ import { Alert, AlertDescription } from "@/components/ui/alert"
 import { AlertDialog, AlertDialogTrigger, AlertDialogContent, AlertDialogTitle, AlertDialogDescription, AlertDialogCancel, AlertDialogAction } from "@/components/ui/alert-dialog"
 import { Mail, Clock, Loader2, Trash2, Heart, AlertCircle, RefreshCw, Inbox, Eye, Pencil, Paperclip, X, Upload, Plus } from 'lucide-react';
 import { apiRequest, uploadFile, deleteAttachment, listAttachments } from "@/lib/api";
+import FarewellLetters from "@/components/FarewellLetters";
 import { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog"
 import { Textarea } from "@/components/ui/textarea"
 import { Select } from "@/components/ui/select"
+import { ALLOWED_EXTENSIONS, MAX_FILE_SIZE, MAX_FILES, MAX_TOTAL_SIZE, EMAIL_REGEX, TIME_PRESETS, REMINDER_PRESETS } from "@/lib/constants"
+import { formatFileSize, formatMinutes } from "@/lib/formatters"
+import { parseRecipientEmails } from "@/lib/parsers"
+import { applyDurationToReminders, addReminderValue, removeReminderValue } from "@/lib/reminder-utils"
 
-const ALLOWED_EXTENSIONS = ['.pdf', '.txt', '.doc', '.docx', '.jpg', '.jpeg', '.png', '.gif', '.webp', '.zip'];
-const MAX_FILE_SIZE = 10 * 1024 * 1024;
-const MAX_FILES = 5;
-const MAX_TOTAL_SIZE = 25 * 1024 * 1024;
 const RECIPIENT_PREVIEW_LIMIT = 3;
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-
-function parseRecipientEmails(value) {
-    const parts = String(value || '')
-        .split(/[\n,;]+/)
-        .map((entry) => entry.trim())
-        .filter(Boolean);
-
-    const seen = new Set();
-    const unique = [];
-    for (const email of parts) {
-        const key = email.toLowerCase();
-        if (!seen.has(key)) {
-            seen.add(key);
-            unique.push(email);
-        }
-    }
-    return unique;
-}
 
 function formatRecipientEmails(value) {
-    const recipients = parseRecipientEmails(value);
-    return recipients.join(', ');
-}
-
-function formatFileSize(bytes) {
-    if (bytes < 1024) return bytes + ' B';
-    if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
-    return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
-}
-
-function formatMinutes(minutes) {
-    if (minutes >= 1440) {
-        // e.g., 2880 -> 2, 3600 -> 2.5
-        const days = Number((minutes / 1440).toFixed(1));
-        return `${days} Day${days !== 1 ? 's' : ''} Before`;
-    }
-    if (minutes >= 60) {
-        const hours = Number((minutes / 60).toFixed(1));
-        return `${hours} Hour${hours !== 1 ? 's' : ''} Before`;
-    }
-    return `${minutes} Minutes Before`;
+    return parseRecipientEmails(value).join(', ');
 }
 
 export default function Dashboard() {
@@ -141,55 +103,18 @@ export default function Dashboard() {
     const [editAttachLoading, setEditAttachLoading] = useState(false);
     const editFileInputRef = useRef(null);
 
-    const timePresets = [
-        { label: '1 Minute (Debug)', value: 1 },
-        { label: '15 Minutes (Test)', value: 15 },
-        { label: '1 Hour', value: 60 },
-        { label: '1 Day', value: 1440 },
-        { label: '3 Days', value: 4320 },
-        { label: '1 Week', value: 10080 },
-        { label: '2 Weeks', value: 20160 },
-        { label: '1 Month', value: 43200 },
-        { label: '3 Months', value: 129600 },
-        { label: '6 Months', value: 259200 },
-        { label: '1 Year', value: 525600 },
-    ];
-
-    const reminderPresets = [
-        { label: '15 Minutes Before', value: 15 },
-        { label: '1 Hour Before', value: 60 },
-        { label: '12 Hours Before', value: 720 },
-        { label: '1 Day Before', value: 1440 },
-        { label: '2 Days Before', value: 2880 },
-        { label: '3 Days Before', value: 4320 },
-        { label: '5 Days Before', value: 7200 },
-        { label: '10 Days Before', value: 14400 },
-    ];
 
     const handleEditDurationChange = (newDuration) => {
         setEditDuration(newDuration);
-        const validReminders = editReminders.filter(r => r < newDuration);
-        if (validReminders.length === 0) {
-            if (newDuration >= 1440) {
-                setEditReminders([newDuration / 2]);
-            } else if (newDuration >= 60) {
-                setEditReminders([15]);
-            } else {
-                setEditReminders([]);
-            }
-        } else {
-            setEditReminders(validReminders);
-        }
+        setEditReminders((prev) => applyDurationToReminders(prev, newDuration));
     };
 
     const addEditReminder = (value) => {
-        if (!editReminders.includes(value) && value < editDuration) {
-            setEditReminders([...editReminders, value].sort((a, b) => b - a)); // sort descending
-        }
+        setEditReminders((prev) => addReminderValue(prev, value, editDuration));
     };
 
     const removeEditReminder = (value) => {
-        setEditReminders(editReminders.filter(r => r !== value));
+        setEditReminders((prev) => removeReminderValue(prev, value));
     };
 
     const openEditDialog = async (message) => {
@@ -814,7 +739,7 @@ export default function Dashboard() {
                                 onChange={(e) => handleEditDurationChange(Number(e.target.value))}
                                 className="bg-dark-950 border-dark-700 text-dark-100"
                             >
-                                {timePresets.map(preset => (
+                                {TIME_PRESETS.map(preset => (
                                     <option key={preset.value} value={preset.value}>
                                         {preset.label}
                                     </option>
@@ -833,12 +758,12 @@ export default function Dashboard() {
                                 {editReminders.length > 0 ? (
                                     <div className="flex flex-wrap gap-2">
                                         {editReminders.map(r => {
-                                            const preset = reminderPresets.find(p => p.value === r);
+                                            const preset = REMINDER_PRESETS.find(p => p.value === r);
                                             const label = preset ? preset.label : formatMinutes(r);
                                             return (
                                                 <div key={r} className="flex items-center gap-1 bg-dark-800 text-dark-200 text-xs px-2 py-1 rounded">
                                                     <span>{label}</span>
-                                                    <button onClick={() => removeEditReminder(r)} className="text-dark-400 hover:text-red-400">
+                                                    <button type="button" onClick={() => removeEditReminder(r)} className="text-dark-400 hover:text-red-400">
                                                         <X className="w-3 h-3" />
                                                     </button>
                                                 </div>
@@ -861,7 +786,7 @@ export default function Dashboard() {
                                         value={""}
                                     >
                                         <option value="" disabled>Add a reminder...</option>
-                                        {reminderPresets.filter(p => !editReminders.includes(p.value) && p.value < editDuration).map(preset => (
+                                        {REMINDER_PRESETS.filter(p => !editReminders.includes(p.value) && p.value < editDuration).map(preset => (
                                             <option key={preset.value} value={preset.value}>
                                                 {preset.label}
                                             </option>
@@ -870,6 +795,9 @@ export default function Dashboard() {
                                 </div>
                             </div>
                         </div>
+                    </div>
+                    <div className="border-t border-dark-700 pt-4 mt-2">
+                        <FarewellLetters messageId={editingMessage?.id} />
                     </div>
                     <div className="flex flex-col-reverse sm:flex-row justify-end gap-2 mt-6">
                         <Button

--- a/frontend/src/components/FarewellLetters.jsx
+++ b/frontend/src/components/FarewellLetters.jsx
@@ -16,7 +16,7 @@ import {
     deleteFarewellLetter, uploadFarewellAttachment,
     listFarewellAttachments, deleteFarewellAttachment
 } from "@/lib/api";
-import { ALLOWED_EXTENSIONS, MAX_FILE_SIZE, MAX_FILES, MAX_TOTAL_SIZE, FAREWELL_DELAY_PRESETS } from "@/lib/constants"
+import { ALLOWED_EXTENSIONS, MAX_FILE_SIZE, MAX_FILES, MAX_TOTAL_SIZE, FAREWELL_DELAY_PRESETS, EMAIL_REGEX } from "@/lib/constants"
 import { formatFileSize, formatFarewellDelay } from "@/lib/formatters"
 
 function renderSafeMarkdown(markdown) {
@@ -146,7 +146,7 @@ function AttachmentManager({ messageId, letterId: propLetterId, disabled, pendin
                     <label className="cursor-pointer flex items-center gap-1 text-xs text-teal-400 hover:text-teal-300">
                         <Upload className="w-3 h-3" />
                         {uploading ? "Uploading..." : (letterIdState ? "Add file" : "Queue file")}
-                        <input type="file" className="hidden" onChange={handleUpload} disabled={uploading || attachments.length + pendingFiles.length >= MAX_FILES} />
+                        <input type="file" className="hidden" onChange={handleUpload} disabled={uploading || attachments.length + pendingFiles.length >= MAX_FILES} accept={ALLOWED_EXTENSIONS.join(',')} />
                     </label>
                 )}
             </div>
@@ -207,6 +207,20 @@ function LetterForm({ messageId, letter, onSave, onCancel }) {
 
     async function handleSave() {
         setError(null);
+
+        if (!recipientEmail.trim() || !EMAIL_REGEX.test(recipientEmail.trim())) {
+            setError('Please enter a valid recipient email address.');
+            return;
+        }
+        if (!subject.trim()) {
+            setError('Subject is required.');
+            return;
+        }
+        if (!content.trim()) {
+            setError('Message content is required.');
+            return;
+        }
+
         setSaving(true);
         try {
             const isNewLetter = !savedLetterId;
@@ -218,14 +232,9 @@ function LetterForm({ messageId, letter, onSave, onCancel }) {
                 saved = await createFarewellLetter(messageId, payload);
             }
 
-            if (pendingFiles.length > 0) {
-                const remainingFiles = [...pendingFiles];
-                while (remainingFiles.length > 0) {
-                    const nextFile = remainingFiles[0];
-                    await uploadFarewellAttachment(messageId, saved.id, nextFile);
-                    remainingFiles.shift();
-                }
-                setPendingFiles(remainingFiles);
+            for (const file of pendingFiles) {
+                await uploadFarewellAttachment(messageId, saved.id, file);
+                setPendingFiles(prev => prev.filter(f => f !== file));
             }
 
             setSavedLetterId(saved.id);

--- a/frontend/src/components/FarewellLetters.jsx
+++ b/frontend/src/components/FarewellLetters.jsx
@@ -1,0 +1,524 @@
+import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
+import { marked } from 'marked';
+import DOMPurify from 'dompurify';
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { AlertDialog, AlertDialogTrigger, AlertDialogContent, AlertDialogTitle, AlertDialogDescription, AlertDialogCancel, AlertDialogAction } from "@/components/ui/alert-dialog";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
+import {
+    Mail, Clock, Trash2, Paperclip, X, Plus, Loader2, CheckCircle,
+    AlertCircle, Eye, Pencil, Upload, Send
+} from 'lucide-react';
+import {
+    listFarewellLetters, createFarewellLetter, updateFarewellLetter,
+    deleteFarewellLetter, uploadFarewellAttachment,
+    listFarewellAttachments, deleteFarewellAttachment
+} from "@/lib/api";
+import { ALLOWED_EXTENSIONS, MAX_FILE_SIZE, MAX_FILES, MAX_TOTAL_SIZE, FAREWELL_DELAY_PRESETS } from "@/lib/constants"
+import { formatFileSize, formatFarewellDelay } from "@/lib/formatters"
+
+function renderSafeMarkdown(markdown) {
+    const rendered = marked.parse(markdown || '');
+    const html = typeof rendered === 'string' ? rendered : '';
+    return DOMPurify.sanitize(html, {
+        USE_PROFILES: { html: true },
+    });
+}
+
+function MarkdownEditor({ value, onChange }) {
+    const [preview, setPreview] = useState(false);
+    const previewHtml = useMemo(() => renderSafeMarkdown(value), [value]);
+
+    return (
+        <div className="space-y-1">
+            <div className="flex items-center justify-between">
+                <span className="text-xs text-dark-400">Supports Markdown formatting</span>
+                <button
+                    type="button"
+                    onClick={() => setPreview(!preview)}
+                    className="flex items-center gap-1 text-xs text-teal-400 hover:text-teal-300"
+                >
+                    {preview ? <><Pencil className="w-3 h-3" /> Edit</> : <><Eye className="w-3 h-3" /> Preview</>}
+                </button>
+            </div>
+            {preview ? (
+                <div
+                    className="min-h-[160px] p-3 rounded-md border border-dark-700 bg-dark-950 text-dark-100 text-sm prose prose-invert max-w-none overflow-auto"
+                    dangerouslySetInnerHTML={{ __html: previewHtml }}
+                />
+            ) : (
+                <Textarea
+                    value={value}
+                    onChange={(e) => onChange(e.target.value)}
+                    placeholder="Write your farewell message here... Markdown is supported."
+                    className="min-h-[160px] bg-dark-950 border-dark-700 focus:border-teal-500 text-dark-100 placeholder:text-dark-500 font-mono text-sm"
+                />
+            )}
+        </div>
+    );
+}
+
+function AttachmentManager({ messageId, letterId: propLetterId, disabled, pendingFiles = [], onPendingFilesChange }) {
+    const [letterIdState, setLetterIdState] = useState(propLetterId);
+    const [attachments, setAttachments] = useState([]);
+    const [uploading, setUploading] = useState(false);
+    const [error, setError] = useState(null);
+
+    const loadAttachments = useCallback(async (letterId) => {
+        if (!letterId) return;
+        try {
+            const data = await listFarewellAttachments(messageId, letterId);
+            setAttachments(data || []);
+        } catch {
+            // non-fatal
+        }
+    }, [messageId]);
+
+    useEffect(() => {
+        setLetterIdState(propLetterId);
+        if (propLetterId) {
+            loadAttachments(propLetterId);
+        } else {
+            setAttachments([]);
+        }
+    }, [propLetterId, loadAttachments]);
+
+    function validateFile(file) {
+        const ext = '.' + file.name.split('.').pop().toLowerCase();
+        if (!ALLOWED_EXTENSIONS.includes(ext)) return `File type ${ext} is not allowed`;
+        if (file.size > MAX_FILE_SIZE) return `File exceeds 10 MB limit`;
+        if (attachments.length + pendingFiles.length >= MAX_FILES) return `Maximum ${MAX_FILES} attachments`;
+        const totalSize = attachments.reduce((s, a) => s + a.size, 0) + pendingFiles.reduce((s, f) => s + f.size, 0);
+        if (totalSize + file.size > MAX_TOTAL_SIZE) return `Total size would exceed 25 MB`;
+        return null;
+    }
+
+    async function handleUpload(e) {
+        const file = e.target.files?.[0];
+        if (!file) return;
+        const err = validateFile(file);
+        if (err) { setError(err); e.target.value = ''; return; }
+
+        const lid = letterIdState;
+
+        if (!lid) {
+            onPendingFilesChange?.(prev => [...prev, file]);
+            setError(null);
+            e.target.value = '';
+            return;
+        }
+
+        setUploading(true);
+        setError(null);
+        try {
+            await uploadFarewellAttachment(messageId, lid, file);
+            await loadAttachments(lid);
+        } catch (err) {
+            setError(err.message);
+        } finally {
+            setUploading(false);
+            e.target.value = '';
+        }
+    }
+
+    function removePendingFile(indexToRemove) {
+        onPendingFilesChange?.(prev => prev.filter((_, index) => index !== indexToRemove));
+    }
+
+    async function handleDelete(attachmentId) {
+        try {
+            await deleteFarewellAttachment(messageId, letterIdState, attachmentId);
+            setAttachments(prev => prev.filter(a => a.id !== attachmentId));
+        } catch (err) {
+            setError(err.message);
+        }
+    }
+
+    return (
+        <div className="space-y-2">
+            <div className="flex items-center justify-between">
+                <label className="text-xs font-medium text-dark-400 flex items-center gap-1">
+                    <Paperclip className="w-3 h-3" /> Attachments ({attachments.length + pendingFiles.length}/{MAX_FILES})
+                </label>
+                {!disabled && (
+                    <label className="cursor-pointer flex items-center gap-1 text-xs text-teal-400 hover:text-teal-300">
+                        <Upload className="w-3 h-3" />
+                        {uploading ? "Uploading..." : (letterIdState ? "Add file" : "Queue file")}
+                        <input type="file" className="hidden" onChange={handleUpload} disabled={uploading || attachments.length + pendingFiles.length >= MAX_FILES} />
+                    </label>
+                )}
+            </div>
+            {error && <p className="text-xs text-red-400">{error}</p>}
+            {!letterIdState && pendingFiles.length > 0 && (
+                <p className="text-xs text-dark-500">Files will upload when you save the letter.</p>
+            )}
+            {attachments.length > 0 && (
+                <div className="space-y-1">
+                    {attachments.map(att => (
+                        <div key={att.id} className="flex items-center justify-between bg-dark-900 border border-dark-700 rounded px-2 py-1.5">
+                            <div className="flex items-center gap-2 min-w-0">
+                                <Paperclip className="w-3 h-3 text-dark-400 shrink-0" />
+                                <span className="text-xs text-dark-200 truncate">{att.filename}</span>
+                                <span className="text-xs text-dark-500 shrink-0">{formatFileSize(att.size)}</span>
+                            </div>
+                            {!disabled && (
+                                <button type="button" onClick={() => handleDelete(att.id)} className="text-dark-500 hover:text-red-400 ml-2">
+                                    <X className="w-3 h-3" />
+                                </button>
+                            )}
+                        </div>
+                    ))}
+                </div>
+            )}
+            {pendingFiles.length > 0 && (
+                <div className="space-y-1">
+                    {pendingFiles.map((file, index) => (
+                        <div key={`${file.name}-${file.size}-${index}`} className="flex items-center justify-between bg-dark-900 border border-dark-700 rounded px-2 py-1.5">
+                            <div className="flex items-center gap-2 min-w-0">
+                                <Paperclip className="w-3 h-3 text-dark-400 shrink-0" />
+                                <span className="text-xs text-dark-200 truncate">{file.name}</span>
+                                <span className="text-xs text-dark-500 shrink-0">{formatFileSize(file.size)}</span>
+                                <span className="text-[10px] text-amber-400 shrink-0">Queued</span>
+                            </div>
+                            {!disabled && (
+                                <button type="button" onClick={() => removePendingFile(index)} className="text-dark-500 hover:text-red-400 ml-2">
+                                    <X className="w-3 h-3" />
+                                </button>
+                            )}
+                        </div>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}
+
+function LetterForm({ messageId, letter, onSave, onCancel }) {
+    const [recipientEmail, setRecipientEmail] = useState(letter?.recipient_email || '');
+    const [subject, setSubject] = useState(letter?.subject || '');
+    const [content, setContent] = useState(letter?.content || '');
+    const [delayMinutes, setDelayMinutes] = useState(letter?.delay_minutes ?? 1440);
+    const [saving, setSaving] = useState(false);
+    const [error, setError] = useState(null);
+    const [savedLetterId, setSavedLetterId] = useState(letter?.id || null);
+    const [pendingFiles, setPendingFiles] = useState([]);
+
+    async function handleSave() {
+        setError(null);
+        setSaving(true);
+        try {
+            const isNewLetter = !savedLetterId;
+            const payload = { recipient_email: recipientEmail, subject, content, delay_minutes: delayMinutes };
+            let saved;
+            if (savedLetterId) {
+                saved = await updateFarewellLetter(messageId, savedLetterId, payload);
+            } else {
+                saved = await createFarewellLetter(messageId, payload);
+            }
+
+            if (pendingFiles.length > 0) {
+                const remainingFiles = [...pendingFiles];
+                while (remainingFiles.length > 0) {
+                    const nextFile = remainingFiles[0];
+                    await uploadFarewellAttachment(messageId, saved.id, nextFile);
+                    remainingFiles.shift();
+                }
+                setPendingFiles(remainingFiles);
+            }
+
+            setSavedLetterId(saved.id);
+            onSave(saved, { isNewLetter });
+        } catch (err) {
+            setError(err.message);
+        } finally {
+            setSaving(false);
+        }
+    }
+
+    const isSent = letter?.status === 'sent';
+
+    return (
+        <div className="space-y-4 p-4 border border-dark-700 rounded-lg bg-dark-900">
+            {error && (
+                <Alert variant="destructive" className="border-red-800 bg-red-950/50">
+                    <AlertCircle className="h-4 w-4" />
+                    <AlertDescription>{error}</AlertDescription>
+                </Alert>
+            )}
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                <div className="space-y-1">
+                    <label className="text-xs font-medium text-dark-400 flex items-center gap-1">
+                        <Mail className="w-3 h-3" /> Recipient email
+                    </label>
+                    <Input
+                        type="email"
+                        placeholder="someone@example.com"
+                        value={recipientEmail}
+                        onChange={(e) => setRecipientEmail(e.target.value)}
+                        disabled={isSent}
+                        className="bg-dark-950 border-dark-700 focus:border-teal-500 text-dark-100 placeholder:text-dark-500"
+                    />
+                </div>
+                <div className="space-y-1">
+                    <label className="text-xs font-medium text-dark-400 flex items-center gap-1">
+                        <Clock className="w-3 h-3" /> Send delay
+                    </label>
+                    <select
+                        value={delayMinutes}
+                        onChange={(e) => setDelayMinutes(Number(e.target.value))}
+                        disabled={isSent}
+                        className="w-full h-9 rounded-md border border-dark-700 bg-dark-950 text-dark-100 text-sm px-3 focus:outline-none focus:border-teal-500"
+                    >
+                        {FAREWELL_DELAY_PRESETS.map(p => (
+                            <option key={p.value} value={p.value}>{p.label}</option>
+                        ))}
+                    </select>
+                </div>
+            </div>
+
+            <div className="space-y-1">
+                <label className="text-xs font-medium text-dark-400">Subject</label>
+                <Input
+                    type="text"
+                    placeholder="A farewell message for you"
+                    value={subject}
+                    onChange={(e) => setSubject(e.target.value)}
+                    disabled={isSent}
+                    className="bg-dark-950 border-dark-700 focus:border-teal-500 text-dark-100 placeholder:text-dark-500"
+                />
+            </div>
+
+            <div className="space-y-1">
+                <label className="text-xs font-medium text-dark-400">Message</label>
+                <MarkdownEditor value={content} onChange={setContent} />
+            </div>
+
+            <AttachmentManager
+                messageId={messageId}
+                letterId={savedLetterId}
+                disabled={isSent || saving}
+                pendingFiles={pendingFiles}
+                onPendingFilesChange={setPendingFiles}
+            />
+
+            {isSent ? (
+                <p className="text-xs text-teal-400 flex items-center gap-1">
+                    <Send className="w-3 h-3" /> This letter has already been sent
+                </p>
+            ) : (
+                <div className="flex gap-2 justify-end">
+                    <Button variant="outline" size="sm" onClick={onCancel}
+                        className="border-dark-700 bg-dark-900 hover:bg-dark-800 text-dark-200">
+                        {savedLetterId ? 'Done' : 'Cancel'}
+                    </Button>
+                    <Button size="sm" onClick={handleSave} disabled={saving}
+                        className="bg-teal-600 hover:bg-teal-500 text-white">
+                        {saving
+                            ? <><Loader2 className="w-3 h-3 mr-1 animate-spin" /> Saving...</>
+                            : (savedLetterId ? 'Save changes' : 'Save letter')}
+                    </Button>
+                </div>
+            )}
+        </div>
+    );
+}
+
+export default function FarewellLetters({ messageId }) {
+    const [letters, setLetters] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+    const [editingLetter, setEditingLetter] = useState(null);
+    const [showForm, setShowForm] = useState(false);
+    const [toastMessage, setToastMessage] = useState('');
+    const toastTimeoutRef = useRef(null);
+
+    const loadLetters = useCallback(async () => {
+        if (!messageId) return;
+        setLoading(true);
+        try {
+            const data = await listFarewellLetters(messageId);
+            setLetters(data || []);
+        } catch (err) {
+            setError(err.message);
+        } finally {
+            setLoading(false);
+        }
+    }, [messageId]);
+
+    useEffect(() => {
+        loadLetters();
+    }, [loadLetters]);
+
+    useEffect(() => {
+        return () => {
+            if (toastTimeoutRef.current) {
+                clearTimeout(toastTimeoutRef.current);
+            }
+        };
+    }, []);
+
+    function showToast(message) {
+        setToastMessage(message);
+        if (toastTimeoutRef.current) {
+            clearTimeout(toastTimeoutRef.current);
+        }
+        toastTimeoutRef.current = setTimeout(() => {
+            setToastMessage('');
+            toastTimeoutRef.current = null;
+        }, 3000);
+    }
+
+    function handleSaved(saved, meta = {}) {
+        setLetters(prev => {
+            const idx = prev.findIndex(l => l.id === saved.id);
+            if (idx >= 0) {
+                const next = [...prev];
+                next[idx] = saved;
+                return next;
+            }
+            return [...prev, saved];
+        });
+        setShowForm(false);
+        setEditingLetter(null);
+        showToast(meta.isNewLetter ? 'Letter saved to switch' : 'Letter changes saved');
+    }
+
+    function handleDismiss() {
+        setShowForm(false);
+        setEditingLetter(null);
+    }
+
+    async function handleDelete(letterId) {
+        try {
+            await deleteFarewellLetter(messageId, letterId);
+            setLetters(prev => prev.filter(l => l.id !== letterId));
+        } catch (err) {
+            setError(err.message);
+        }
+    }
+
+    if (loading) {
+        return (
+            <div className="flex items-center justify-center py-6 text-dark-400">
+                <Loader2 className="w-4 h-4 animate-spin mr-2" /> Loading farewell letters...
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-3">
+            {toastMessage && (
+                <div className="fixed right-4 top-20 z-[300] max-w-xs rounded-lg border border-teal-500/30 bg-dark-900 px-3 py-2 shadow-lg">
+                    <div className="flex items-center gap-2 text-sm text-teal-300">
+                        <CheckCircle className="h-4 w-4 shrink-0 text-teal-400" />
+                        <span>{toastMessage}</span>
+                    </div>
+                </div>
+            )}
+            <div className="flex items-center justify-between">
+                <div>
+                    <h3 className="text-sm font-medium text-dark-100">Farewell Letters</h3>
+                    <p className="text-xs text-dark-400 mt-0.5">
+                        Personal messages sent after this switch fires, each with its own delay.
+                    </p>
+                </div>
+                {!showForm && !editingLetter && (
+                    <Button size="sm" variant="outline" onClick={() => setShowForm(true)}
+                        className="border-dark-700 bg-dark-900 hover:bg-dark-800 text-dark-200 shrink-0">
+                        <Plus className="w-3 h-3 mr-1" /> Add letter
+                    </Button>
+                )}
+            </div>
+
+            {error && (
+                <Alert variant="destructive" className="border-red-800 bg-red-950/50">
+                    <AlertCircle className="h-4 w-4" />
+                    <AlertDescription>{error}</AlertDescription>
+                </Alert>
+            )}
+
+            {(showForm && !editingLetter) && (
+                <LetterForm
+                    messageId={messageId}
+                    onSave={handleSaved}
+                    onCancel={handleDismiss}
+                />
+            )}
+
+            {letters.length === 0 && !showForm ? (
+                <div className="text-center py-6 text-dark-500 text-xs border border-dashed border-dark-700 rounded-lg">
+                    No farewell letters configured yet.
+                </div>
+            ) : (
+                <div className="space-y-2">
+                    {letters.map(letter => (
+                        <div key={letter.id}>
+                            {editingLetter?.id === letter.id ? (
+                                <LetterForm
+                                    messageId={messageId}
+                                    letter={letter}
+                                    onSave={handleSaved}
+                                    onCancel={handleDismiss}
+                                />
+                            ) : (
+                                <div className="flex items-start justify-between gap-3 p-3 border border-dark-700 rounded-lg bg-dark-900 hover:border-dark-600 transition-colors">
+                                    <div className="min-w-0 flex-1 space-y-1">
+                                        <div className="flex items-center gap-2 flex-wrap">
+                                            <span className="text-xs font-medium text-dark-100 truncate">{letter.subject}</span>
+                                            {letter.status === 'sent' ? (
+                                                <span className="text-xs px-1.5 py-0.5 rounded bg-teal-900/50 text-teal-400 border border-teal-800 shrink-0">Sent</span>
+                                            ) : (
+                                                <span className="text-xs px-1.5 py-0.5 rounded bg-dark-800 text-dark-400 border border-dark-700 shrink-0">Pending</span>
+                                            )}
+                                        </div>
+                                        <div className="flex items-center gap-3 text-xs text-dark-400">
+                                            <span className="flex items-center gap-1"><Mail className="w-3 h-3" />{letter.recipient_email}</span>
+                                            <span className="flex items-center gap-1"><Clock className="w-3 h-3" />{formatFarewellDelay(letter.delay_minutes)}</span>
+                                            {letter.attachment_count > 0 && (
+                                                <span className="flex items-center gap-1"><Paperclip className="w-3 h-3" />{letter.attachment_count}</span>
+                                            )}
+                                        </div>
+                                    </div>
+                                    {letter.status !== 'sent' && (
+                                        <div className="flex items-center gap-1 shrink-0">
+                                            <Button size="sm" variant="ghost" onClick={() => setEditingLetter(letter)}
+                                                className="h-7 w-7 p-0 text-dark-400 hover:text-dark-100 hover:bg-dark-800">
+                                                <Pencil className="w-3 h-3" />
+                                            </Button>
+                                            <AlertDialog>
+                                                <AlertDialogTrigger asChild>
+                                                    <Button size="sm" variant="ghost"
+                                                        className="h-7 w-7 p-0 text-dark-400 hover:text-red-400 hover:bg-red-950/30">
+                                                        <Trash2 className="w-3 h-3" />
+                                                    </Button>
+                                                </AlertDialogTrigger>
+                                                <AlertDialogContent className="bg-dark-900 border-dark-700">
+                                                    <AlertDialogTitle>Delete farewell letter?</AlertDialogTitle>
+                                                    <AlertDialogDescription className="text-dark-400">
+                                                        This letter and its attachments will be permanently deleted.
+                                                    </AlertDialogDescription>
+                                                    <div className="flex gap-2 justify-end mt-2">
+                                                        <AlertDialogCancel className="border-dark-700 bg-dark-900 hover:bg-dark-800 text-dark-200">
+                                                            Cancel
+                                                        </AlertDialogCancel>
+                                                        <AlertDialogAction onClick={() => handleDelete(letter.id)}
+                                                            className="bg-red-600 hover:bg-red-500 text-white border-0">
+                                                            Delete
+                                                        </AlertDialogAction>
+                                                    </div>
+                                                </AlertDialogContent>
+                                            </AlertDialog>
+                                        </div>
+                                    )}
+                                </div>
+                            )}
+                        </div>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/components/SecurityBanner.jsx
+++ b/frontend/src/components/SecurityBanner.jsx
@@ -1,15 +1,23 @@
 import { useState } from 'react';
+import { AlertTriangle, X } from 'lucide-react';
 
 export default function SecurityBanner() {
-    const [isInsecure] = useState(() => window.location.protocol !== 'https:');
+    const isInsecure = window.location.protocol !== 'https:';
     const [dismissed, setDismissed] = useState(() => {
-        // Check localStorage for dismissed state
-        return localStorage.getItem('security-banner-dismissed') === 'true';
+        try {
+            return window.localStorage.getItem('security-banner-dismissed') === 'true';
+        } catch {
+            return false;
+        }
     });
 
     const handleDismiss = () => {
         setDismissed(true);
-        localStorage.setItem('security-banner-dismissed', 'true');
+        try {
+            window.localStorage.setItem('security-banner-dismissed', 'true');
+        } catch {
+            // ignore storage write errors
+        }
     };
 
     if (!isInsecure || dismissed) {
@@ -24,19 +32,7 @@ export default function SecurityBanner() {
             <div className="fixed top-0 left-0 right-0 z-[9999] bg-gradient-to-r from-red-600 to-orange-600 text-white py-2 px-3 sm:px-4 shadow-lg">
                 <div className="container mx-auto flex items-center justify-between gap-2 sm:gap-4">
                     <div className="flex items-center gap-2 sm:gap-3 min-w-0">
-                        <svg
-                            className="w-4 h-4 sm:w-5 sm:h-5 flex-shrink-0"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
-                        >
-                            <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                strokeWidth={2}
-                                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
-                            />
-                        </svg>
+                        <AlertTriangle className="w-4 h-4 sm:w-5 sm:h-5 flex-shrink-0" />
                         <span className="text-xs sm:text-sm font-medium truncate sm:whitespace-normal">
                             <span className="font-bold">Not Secure:</span>
                             <span className="hidden sm:inline"> This connection is not encrypted (HTTP). Your sensitive data is not fully protected.</span>
@@ -46,11 +42,9 @@ export default function SecurityBanner() {
                     <button
                         onClick={handleDismiss}
                         className="text-white/80 hover:text-white transition-colors p-1 flex-shrink-0"
-                        aria-label="Kapat"
+                        aria-label="Dismiss security warning"
                     >
-                        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                        </svg>
+                        <X className="w-4 h-4" />
                     </button>
                 </div>
             </div>

--- a/frontend/src/components/VaultLock.jsx
+++ b/frontend/src/components/VaultLock.jsx
@@ -145,7 +145,7 @@ export default function VaultLock({ onUnlock }) {
                 if (res?.recovery_key) {
                     setShowRecoveryKey(res.recovery_key);
                 } else {
-                    onUnlock();
+                    onUnlock('dashboard');
                 }
             } else if (configured === true && isRegisterMode) {
                 if (!passwordStrength.isValid) {
@@ -175,7 +175,7 @@ export default function VaultLock({ onUnlock }) {
                 if (res?.recovery_key) {
                     setShowRecoveryKey(res.recovery_key);
                 } else {
-                    onUnlock();
+                    onUnlock('home');
                 }
             } else if (configured === false) {
                 if (!passwordStrength.isValid) {
@@ -205,7 +205,7 @@ export default function VaultLock({ onUnlock }) {
                 if (res?.recovery_key) {
                     setShowRecoveryKey(res.recovery_key);
                 } else {
-                    onUnlock();
+                    onUnlock('home');
                 }
             } else {
                 if (!email.trim()) {
@@ -217,7 +217,7 @@ export default function VaultLock({ onUnlock }) {
                     method: 'POST',
                     body: JSON.stringify({ email: email.trim(), password })
                 });
-                onUnlock();
+                onUnlock('dashboard');
             }
         } catch (e) {
             const errorMessage = e.message || '';

--- a/frontend/src/components/ui/alert-dialog.jsx
+++ b/frontend/src/components/ui/alert-dialog.jsx
@@ -39,7 +39,7 @@ const AlertDialogTrigger = ({ asChild, children }) => {
         })
     }
 
-    return <button onClick={() => setOpen(true)}>{children}</button>
+    return <button type="button" onClick={() => setOpen(true)}>{children}</button>
 }
 
 const AlertDialogContent = () => {
@@ -62,6 +62,7 @@ const AlertDialogAction = ({ onClick, children, className = "" }) => {
     const { setOpen } = useContext(AlertDialogContext)
     return (
         <button
+            type="button"
             onClick={(e) => {
                 onClick?.(e)
                 setOpen(false)
@@ -77,6 +78,7 @@ const AlertDialogCancel = ({ onClick, children }) => {
     const { setOpen } = useContext(AlertDialogContext)
     return (
         <button
+            type="button"
             onClick={(e) => {
                 onClick?.(e)
                 setOpen(false)

--- a/frontend/src/components/ui/button.jsx
+++ b/frontend/src/components/ui/button.jsx
@@ -43,12 +43,15 @@ function Button({
   variant = "default",
   size = "default",
   asChild = false,
+  type,
   ...props
 }) {
   const Comp = asChild ? Slot.Root : "button"
+  const resolvedType = asChild ? undefined : (type || "button")
 
   return (
     <Comp
+      type={resolvedType}
       data-slot="button"
       data-variant={variant}
       data-size={size}

--- a/frontend/src/components/ui/dialog.jsx
+++ b/frontend/src/components/ui/dialog.jsx
@@ -29,7 +29,7 @@ const DialogTrigger = ({ asChild, children }) => {
         })
     }
 
-    return <button onClick={() => setOpen(true)}>{children}</button>
+    return <button type="button" onClick={() => setOpen(true)}>{children}</button>
 }
 
 const DialogContent = ({ children, className = "", contentClassName = "" }) => {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -113,8 +113,12 @@ button:focus-visible {
   @apply bg-dark-600;
 }
 
-/* Smooth transitions */
-* {
+/* Smooth transitions on interactive controls only */
+a,
+button,
+input,
+select,
+textarea {
   transition-property: background-color, border-color, color, opacity;
   transition-duration: 150ms;
   transition-timing-function: ease;

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -1,10 +1,36 @@
 export const API_BASE = import.meta.env.VITE_API_URL || "/api";
+const API_ROOT = API_BASE.endsWith("/") ? API_BASE.slice(0, -1) : API_BASE;
+
+function buildApiUrl(path) {
+	const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+	return `${API_ROOT}${normalizedPath}`;
+}
+
+async function parseResponse(response, errorPrefix = "Request failed") {
+	let data = null;
+	let rawText = "";
+
+	try {
+		rawText = await response.text();
+		data = rawText ? JSON.parse(rawText) : null;
+	} catch {
+		data = null;
+	}
+
+	if (!response.ok) {
+		const message =
+			data?.error ||
+			data?.message ||
+			(rawText ? rawText : `${errorPrefix} (${response.status})`);
+		throw new Error(message);
+	}
+
+	return data;
+}
 
 export async function apiRequest(path, options = {}) {
 	const { headers, ...rest } = options;
-	const base = API_BASE.endsWith("/") ? API_BASE.slice(0, -1) : API_BASE;
-	const normalizedPath = path.startsWith("/") ? path : `/${path}`;
-	const response = await fetch(`${base}${normalizedPath}`, {
+	const response = await fetch(buildApiUrl(path), {
 		credentials: "include",
 		...rest,
 		headers: {
@@ -13,24 +39,7 @@ export async function apiRequest(path, options = {}) {
 		},
 	});
 
-	let data = null;
-	let rawText = "";
-	try {
-		rawText = await response.text();
-		data = rawText ? JSON.parse(rawText) : null;
-	} catch {
-		data = null;
-	}
-
-	if (!response.ok) {
-		const message =
-			data?.error ||
-			data?.message ||
-			(rawText ? rawText : `Request failed (${response.status})`);
-		throw new Error(message);
-	}
-
-	return data;
+	return parseResponse(response, "Request failed");
 }
 
 // Upload a file attachment to a message (multipart/form-data)
@@ -38,32 +47,14 @@ export async function uploadFile(messageId, file) {
 	const formData = new FormData();
 	formData.append("file", file);
 
-	const base = API_BASE.endsWith("/") ? API_BASE.slice(0, -1) : API_BASE;
-	const response = await fetch(`${base}/messages/${messageId}/attachments`, {
+	const response = await fetch(buildApiUrl(`/messages/${messageId}/attachments`), {
 		method: "POST",
 		credentials: "include",
 		body: formData,
 		// Do NOT set Content-Type — browser sets it with correct boundary
 	});
 
-	let data = null;
-	let rawText = "";
-	try {
-		rawText = await response.text();
-		data = rawText ? JSON.parse(rawText) : null;
-	} catch {
-		data = null;
-	}
-
-	if (!response.ok) {
-		const message =
-			data?.error ||
-			data?.message ||
-			(rawText ? rawText : `Upload failed (${response.status})`);
-		throw new Error(message);
-	}
-
-	return data;
+	return parseResponse(response, "Upload failed");
 }
 
 // Delete a file attachment
@@ -76,4 +67,59 @@ export async function deleteAttachment(messageId, attachmentId) {
 // List attachments for a message
 export async function listAttachments(messageId) {
 	return apiRequest(`/messages/${messageId}/attachments`);
+}
+
+// --- Farewell Letters ---
+
+export async function listFarewellLetters(messageId) {
+	return apiRequest(`/messages/${messageId}/farewell-letters`);
+}
+
+export async function createFarewellLetter(messageId, data) {
+	return apiRequest(`/messages/${messageId}/farewell-letters`, {
+		method: "POST",
+		body: JSON.stringify(data),
+	});
+}
+
+export async function updateFarewellLetter(messageId, letterId, data) {
+	return apiRequest(`/messages/${messageId}/farewell-letters/${letterId}`, {
+		method: "PUT",
+		body: JSON.stringify(data),
+	});
+}
+
+export async function deleteFarewellLetter(messageId, letterId) {
+	return apiRequest(`/messages/${messageId}/farewell-letters/${letterId}`, {
+		method: "DELETE",
+	});
+}
+
+export async function uploadFarewellAttachment(messageId, letterId, file) {
+	const formData = new FormData();
+	formData.append("file", file);
+
+	const response = await fetch(
+		buildApiUrl(`/messages/${messageId}/farewell-letters/${letterId}/attachments`),
+		{
+			method: "POST",
+			credentials: "include",
+			body: formData,
+		}
+	);
+
+	return parseResponse(response, "Upload failed");
+}
+
+export async function listFarewellAttachments(messageId, letterId) {
+	return apiRequest(
+		`/messages/${messageId}/farewell-letters/${letterId}/attachments`
+	);
+}
+
+export async function deleteFarewellAttachment(messageId, letterId, attachmentId) {
+	return apiRequest(
+		`/messages/${messageId}/farewell-letters/${letterId}/attachments/${attachmentId}`,
+		{ method: "DELETE" }
+	);
 }

--- a/frontend/src/lib/constants.js
+++ b/frontend/src/lib/constants.js
@@ -1,0 +1,41 @@
+export const ALLOWED_EXTENSIONS = ['.pdf', '.txt', '.doc', '.docx', '.jpg', '.jpeg', '.png', '.gif', '.webp', '.zip'];
+export const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+export const MAX_FILES = 5;
+export const MAX_TOTAL_SIZE = 25 * 1024 * 1024; // 25 MB
+export const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export const TIME_PRESETS = [
+    { label: '1 Minute (Debug)', value: 1 },
+    { label: '15 Minutes (Test)', value: 15 },
+    { label: '1 Hour', value: 60 },
+    { label: '1 Day', value: 1440 },
+    { label: '3 Days', value: 4320 },
+    { label: '1 Week', value: 10080 },
+    { label: '2 Weeks', value: 20160 },
+    { label: '1 Month', value: 43200 },
+    { label: '3 Months', value: 129600 },
+    { label: '6 Months', value: 259200 },
+    { label: '1 Year', value: 525600 },
+];
+
+export const REMINDER_PRESETS = [
+    { label: '15 Minutes Before', value: 15 },
+    { label: '1 Hour Before', value: 60 },
+    { label: '12 Hours Before', value: 720 },
+    { label: '1 Day Before', value: 1440 },
+    { label: '2 Days Before', value: 2880 },
+    { label: '3 Days Before', value: 4320 },
+    { label: '5 Days Before', value: 7200 },
+    { label: '10 Days Before', value: 14400 },
+];
+
+export const FAREWELL_DELAY_PRESETS = [
+    { label: 'Immediately after trigger', value: 0 },
+    { label: '1 hour after trigger', value: 60 },
+    { label: '6 hours after trigger', value: 360 },
+    { label: '12 hours after trigger', value: 720 },
+    { label: '1 day after trigger', value: 1440 },
+    { label: '3 days after trigger', value: 4320 },
+    { label: '1 week after trigger', value: 10080 },
+    { label: '2 weeks after trigger', value: 20160 },
+];

--- a/frontend/src/lib/formatters.js
+++ b/frontend/src/lib/formatters.js
@@ -1,0 +1,29 @@
+import { FAREWELL_DELAY_PRESETS } from './constants.js';
+
+export function formatFileSize(bytes) {
+    if (bytes < 1024) return bytes + ' B';
+    if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
+    return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
+}
+
+export function formatMinutes(minutes) {
+    if (minutes >= 1440) {
+        const days = Number((minutes / 1440).toFixed(1));
+        return `${days} Day${days !== 1 ? 's' : ''} Before`;
+    }
+    if (minutes >= 60) {
+        const hours = Number((minutes / 60).toFixed(1));
+        return `${hours} Hour${hours !== 1 ? 's' : ''} Before`;
+    }
+    return `${minutes} Minutes Before`;
+}
+
+export function formatFarewellDelay(minutes) {
+    const preset = FAREWELL_DELAY_PRESETS.find(p => p.value === minutes);
+    if (preset) return preset.label;
+    if (minutes === 0) return 'Immediately after trigger';
+    if (minutes >= 10080) return `${minutes / 10080} week(s) after trigger`;
+    if (minutes >= 1440) return `${minutes / 1440} day(s) after trigger`;
+    if (minutes >= 60) return `${minutes / 60} hour(s) after trigger`;
+    return `${minutes} minute(s) after trigger`;
+}

--- a/frontend/src/lib/parsers.js
+++ b/frontend/src/lib/parsers.js
@@ -1,0 +1,17 @@
+export function parseRecipientEmails(input) {
+    const parts = String(input || '')
+        .split(/[\n,;]+/)
+        .map((entry) => entry.trim())
+        .filter(Boolean);
+
+    const seen = new Set();
+    const unique = [];
+    for (const email of parts) {
+        const key = email.toLowerCase();
+        if (!seen.has(key)) {
+            seen.add(key);
+            unique.push(email);
+        }
+    }
+    return unique;
+}

--- a/frontend/src/lib/reminder-utils.js
+++ b/frontend/src/lib/reminder-utils.js
@@ -1,0 +1,25 @@
+export function applyDurationToReminders(reminders, newDuration) {
+    const validReminders = reminders.filter((value) => value < newDuration);
+    if (validReminders.length > 0) {
+        return validReminders;
+    }
+
+    if (newDuration >= 1440) {
+        return [newDuration / 2];
+    }
+    if (newDuration >= 60) {
+        return [15];
+    }
+    return [];
+}
+
+export function addReminderValue(reminders, value, maxDuration) {
+    if (reminders.includes(value) || value >= maxDuration) {
+        return reminders;
+    }
+    return [...reminders, value].sort((a, b) => b - a);
+}
+
+export function removeReminderValue(reminders, value) {
+    return reminders.filter((item) => item !== value);
+}


### PR DESCRIPTION
## Commit Summary

This commit fixes the farewell-letter scheduling issue and refactors related frontend/backend code for consistency and safer behavior.

## Backend Changes

1. The farewell handlers now parse request payloads through a shared `parseFarewellPayload` function with explicit validation for `delay_minutes`.
2. `delay_minutes` is now handled as a pointer during parsing and then dereferenced when calling the service, which preserves valid `0` values (immediate send) instead of treating them as missing.
3. The `FarewellLetter` model no longer sets a default `DelayMinutes` value in GORM, avoiding accidental fallback to `1440` minutes when the client intentionally sends `0`.
4. Delete hooks (`Message.BeforeDelete` and `FarewellLetter.BeforeDelete`) were simplified and made safer by using fresh GORM sessions per query, preventing statement-chain leakage across cascade operations.

## Frontend Changes

1. Added a dedicated `FarewellLetters` component to manage letter creation, editing, deletion, attachments, and markdown preview.
2. Added user feedback after save through an in-app toast message and form reset flow.
3. Updated switch creation/dashboard flows to integrate farewell-letter management in a more predictable way.
4. Centralized shared logic into reusable modules:
   - `constants.js` for limits/presets
   - `formatters.js` for display formatting
   - `parsers.js` for recipient parsing
   - `reminder-utils.js` for reminder calculations
5. Refactored `api.js` with shared URL/response helpers and added farewell-letter/attachment API methods.
6. Hardened UI primitives so button-like controls default to `type="button"` where appropriate, preventing unintended form submission side effects.

## Functional Outcome

- Selecting "Immediately after trigger" for a farewell letter now persists as `0` minutes as expected.
- Saving a letter now provides visible confirmation and clears editing state, improving user confidence in the workflow.

# Commit message

- require `delay_minutes` in farewell create/update payloads and pass it as a pointer-backed value to preserve `0` ("immediate") instead of falling back to one day
- remove default `DelayMinutes` at the model level so explicit zero values are not overridden
- harden cascade delete hooks with fresh GORM sessions to avoid statement leakage between queries
- add a reusable Farewell Letters UI with create/edit/delete, queued attachments, markdown preview, and save confirmation toast
- extract shared frontend helpers (constants, formatters, parsers, reminder utilities) and centralize API request/response handling for farewell letter endpoints
- fix button default type behavior in shared UI primitives to prevent accidental form submits