### PR TITLE
feat: add Telegram heartbeat reminders

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -86,6 +86,7 @@ func main() {
 
 	database.DB.Exec("UPDATE messages SET encrypted_content = '' WHERE encrypted_content IS NULL;")
 	database.DB.Exec("UPDATE settings SET webhook_enabled = 0 WHERE webhook_enabled IS NULL;")
+	database.DB.Exec("UPDATE settings SET telegram_enabled = 0 WHERE telegram_enabled IS NULL;")
 
 	if err := services.EnsureUploadsDir(); err != nil {
 		log.Fatal("Failed to create uploads directory: ", err)
@@ -181,7 +182,6 @@ func main() {
 	mgmt.Delete("/messages/:id", messageH.Delete)
 	mgmt.Put("/messages/:id", messageH.Update)
 	mgmt.Post("/heartbeat", messageH.Heartbeat)
-
 	mgmt.Post("/messages/:id/attachments", attachH.Upload)
 	mgmt.Get("/messages/:id/attachments", attachH.List)
 	mgmt.Delete("/messages/:id/attachments/:attachmentId", attachH.Delete)
@@ -202,6 +202,7 @@ func main() {
 	mgmt.Get("/settings", settingsH.Get)
 	mgmt.Post("/settings", settingsH.Save)
 	mgmt.Post("/settings/test", settingsH.TestSMTP)
+	mgmt.Post("/settings/telegram/test", settingsH.TestTelegram)
 	mgmt.Get("/heartbeat-token", heartbeatH.GetToken)
 
 	mgmt.Get("/users", usersH.List)

--- a/backend/internal/handlers/heartbeat.go
+++ b/backend/internal/handlers/heartbeat.go
@@ -4,6 +4,7 @@ import (
 	"github.com/alpyxn/aeterna/backend/internal/ports"
 	"github.com/alpyxn/aeterna/backend/internal/services"
 	"github.com/gofiber/fiber/v2"
+	"strings"
 )
 
 // HeartbeatHandlers groups quick-heartbeat and token route handlers.
@@ -75,7 +76,56 @@ func (h *HeartbeatHandlers) QuickHeartbeat(c *fiber.Ctx) error {
 		return c.SendString(html)
 	}
 
-	html := `<!DOCTYPE html>
+	autoSend := c.Query("auto") == "1"
+	autoScript := ""
+	autoLoadingStyle := "display: none;"
+	if autoSend {
+		autoLoadingStyle = "display: block;"
+		autoScript = `
+        window.addEventListener('load', function() {
+            submitHeartbeat();
+        });
+`
+	}
+
+	autoSubmitCall := `
+        function submitHeartbeat() {
+            const button = document.getElementById('heartbeatButton');
+            const loading = document.getElementById('loading');
+            const postURL = new URL(window.location.href);
+            postURL.searchParams.delete('auto');
+            
+            button.disabled = true;
+            loading.style.display = 'block';
+            
+            fetch(postURL.toString(), {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            })
+            .then(response => {
+                if (response.ok) {
+                    return response.text();
+                }
+                throw new Error('Failed to send heartbeat');
+            })
+            .then(html => {
+                document.body.innerHTML = html;
+            })
+            .catch(error => {
+                button.disabled = false;
+                loading.style.display = 'none';
+                alert('Error: ' + error.message);
+            });
+        }
+`
+
+	html := strings.NewReplacer(
+		"__AUTO_LOADING_STYLE__", autoLoadingStyle,
+		"__AUTO_SUBMIT_CALL__", autoSubmitCall,
+		"__AUTO_SCRIPT__", autoScript,
+	).Replace(`<!DOCTYPE html>
 <html>
 <head>
     <title>Send Heartbeat - Aeterna</title>
@@ -145,7 +195,7 @@ func (h *HeartbeatHandlers) QuickHeartbeat(c *fiber.Ctx) error {
             color: #999;
         }
         .loading {
-            display: none;
+            __AUTO_LOADING_STYLE__
             margin-top: 1rem;
             color: #667eea;
         }
@@ -164,39 +214,16 @@ func (h *HeartbeatHandlers) QuickHeartbeat(c *fiber.Ctx) error {
         <p class="footer">Aeterna</p>
     </div>
     <script>
+__AUTO_SUBMIT_CALL__
+__AUTO_SCRIPT__
         document.getElementById('heartbeatForm').addEventListener('submit', function(e) {
             e.preventDefault();
-            const button = document.getElementById('heartbeatButton');
-            const loading = document.getElementById('loading');
-
-            button.disabled = true;
-            loading.style.display = 'block';
-
-            fetch(window.location.href, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json'
-                }
-            })
-            .then(response => {
-                if (response.ok) {
-                    return response.text();
-                }
-                throw new Error('Failed to send heartbeat');
-            })
-            .then(html => {
-                document.body.innerHTML = html;
-            })
-            .catch(error => {
-                button.disabled = false;
-                loading.style.display = 'none';
-                alert('Error: ' + error.message);
-            });
+            submitHeartbeat();
         });
     </script>
 </body>
 </html>
-`
+`)
 	c.Set("Content-Type", "text/html; charset=utf-8")
 	return c.SendString(html)
 }

--- a/backend/internal/handlers/settings.go
+++ b/backend/internal/handlers/settings.go
@@ -12,6 +12,7 @@ type settingsResponse struct {
 	models.Settings
 	AllowRegistration     bool `json:"allow_registration"`
 	CanManageRegistration bool `json:"can_manage_registration"`
+	TelegramBotConfigured bool `json:"telegram_bot_configured"`
 }
 
 // SettingsHandlers groups SMTP settings and application configuration handlers.
@@ -41,6 +42,7 @@ func (h *SettingsHandlers) Get(c *fiber.Ctx) error {
 		Settings:              settings,
 		AllowRegistration:     app.AllowRegistration,
 		CanManageRegistration: h.appSettings.CanManageRegistration(userID),
+		TelegramBotConfigured: settings.TelegramBotToken != "",
 	})
 }
 
@@ -76,4 +78,19 @@ func (h *SettingsHandlers) TestSMTP(c *fiber.Ctx) error {
 		return writeError(c, err)
 	}
 	return c.JSON(fiber.Map{"success": true, "message": "Connection successful"})
+}
+
+func (h *SettingsHandlers) TestTelegram(c *fiber.Ctx) error {
+	userID, err := currentUserID(c)
+	if err != nil {
+		return writeError(c, err)
+	}
+	var req models.SettingsRequest
+	if err := c.BodyParser(&req); err != nil {
+		return writeError(c, services.BadRequest("Invalid request body", err))
+	}
+	if err := h.settings.TestTelegram(userID, req.ToSettings()); err != nil {
+		return writeError(c, err)
+	}
+	return c.JSON(fiber.Map{"success": true, "message": "Telegram message sent"})
 }

--- a/backend/internal/models/settings.go
+++ b/backend/internal/models/settings.go
@@ -15,22 +15,28 @@ type Settings struct {
 	WebhookURL         string `gorm:"column:webhook_url" json:"webhook_url"`
 	WebhookSecret      string `gorm:"column:webhook_secret" json:"-"` // Hidden from API responses
 	WebhookEnabled     bool   `gorm:"column:webhook_enabled;default:0" json:"webhook_enabled"`
+	TelegramBotToken   string `gorm:"column:telegram_bot_token" json:"-"`
+	TelegramChatID     string `gorm:"column:telegram_chat_id" json:"telegram_chat_id"`
+	TelegramEnabled    bool   `gorm:"column:telegram_enabled;default:0" json:"telegram_enabled"`
 	OwnerEmail         string `gorm:"column:owner_email" json:"owner_email"`
 	HeartbeatToken     string `gorm:"column:heartbeat_token" json:"-"`
 }
 
 // SettingsRequest is used for receiving settings from API (includes sensitive fields)
 type SettingsRequest struct {
-	SMTPHost       string `json:"smtp_host"`
-	SMTPPort       string `json:"smtp_port"`
-	SMTPUser       string `json:"smtp_user"`
-	SMTPPass       string `json:"smtp_pass"` // Accepted from API requests
-	SMTPFrom       string `json:"smtp_from"`
-	SMTPFromName   string `json:"smtp_from_name"`
-	WebhookURL     string `json:"webhook_url"`
-	WebhookSecret  string `json:"webhook_secret"` // Accepted from API requests
-	WebhookEnabled bool   `json:"webhook_enabled"`
-	OwnerEmail     string `json:"owner_email"`
+	SMTPHost         string `json:"smtp_host"`
+	SMTPPort         string `json:"smtp_port"`
+	SMTPUser         string `json:"smtp_user"`
+	SMTPPass         string `json:"smtp_pass"` // Accepted from API requests
+	SMTPFrom         string `json:"smtp_from"`
+	SMTPFromName     string `json:"smtp_from_name"`
+	WebhookURL       string `json:"webhook_url"`
+	WebhookSecret    string `json:"webhook_secret"` // Accepted from API requests
+	WebhookEnabled   bool   `json:"webhook_enabled"`
+	TelegramBotToken string `json:"telegram_bot_token"`
+	TelegramChatID   string `json:"telegram_chat_id"`
+	TelegramEnabled  bool   `json:"telegram_enabled"`
+	OwnerEmail       string `json:"owner_email"`
 	// AllowRegistration: only the primary (first) user may set this; persisted in application_settings.
 	AllowRegistration *bool `json:"allow_registration,omitempty"`
 }
@@ -38,15 +44,18 @@ type SettingsRequest struct {
 // ToSettings converts SettingsRequest to Settings model
 func (r SettingsRequest) ToSettings() Settings {
 	return Settings{
-		SMTPHost:       r.SMTPHost,
-		SMTPPort:       r.SMTPPort,
-		SMTPUser:       r.SMTPUser,
-		SMTPPass:       r.SMTPPass,
-		SMTPFrom:       r.SMTPFrom,
-		SMTPFromName:   r.SMTPFromName,
-		WebhookURL:     r.WebhookURL,
-		WebhookSecret:  r.WebhookSecret,
-		WebhookEnabled: r.WebhookEnabled,
-		OwnerEmail:     r.OwnerEmail,
+		SMTPHost:         r.SMTPHost,
+		SMTPPort:         r.SMTPPort,
+		SMTPUser:         r.SMTPUser,
+		SMTPPass:         r.SMTPPass,
+		SMTPFrom:         r.SMTPFrom,
+		SMTPFromName:     r.SMTPFromName,
+		WebhookURL:       r.WebhookURL,
+		WebhookSecret:    r.WebhookSecret,
+		WebhookEnabled:   r.WebhookEnabled,
+		TelegramBotToken: r.TelegramBotToken,
+		TelegramChatID:   r.TelegramChatID,
+		TelegramEnabled:  r.TelegramEnabled,
+		OwnerEmail:       r.OwnerEmail,
 	}
 }

--- a/backend/internal/ports/ports.go
+++ b/backend/internal/ports/ports.go
@@ -60,6 +60,7 @@ type SettingsServicePort interface {
 	GetByHeartbeatToken(token string) (models.Settings, error)
 	Save(userID string, req models.Settings) error
 	TestSMTP(req models.Settings) error
+	TestTelegram(userID string, req models.Settings) error
 }
 
 // ApplicationSettingsServicePort covers the global (singleton) application settings.

--- a/backend/internal/services/heartbeat_link.go
+++ b/backend/internal/services/heartbeat_link.go
@@ -1,0 +1,20 @@
+package services
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func BuildQuickHeartbeatURL(token string, auto bool) string {
+	baseURL := strings.TrimRight(os.Getenv("BASE_URL"), "/")
+	if baseURL == "" {
+		baseURL = "http://localhost:5173"
+	}
+
+	link := fmt.Sprintf("%s/api/quick-heartbeat/%s", baseURL, token)
+	if auto {
+		link += "?auto=1"
+	}
+	return link
+}

--- a/backend/internal/services/settings_service.go
+++ b/backend/internal/services/settings_service.go
@@ -36,6 +36,13 @@ func (s SettingsService) Get(userID string) (models.Settings, error) {
 		}
 		settings.WebhookSecret = decrypted
 	}
+	if settings.TelegramBotToken != "" {
+		decrypted, err := cryptoService.DecryptIfNeeded(settings.TelegramBotToken)
+		if err != nil {
+			return models.Settings{}, err
+		}
+		settings.TelegramBotToken = decrypted
+	}
 	return settings, nil
 }
 
@@ -54,6 +61,8 @@ func (s SettingsService) GetByHeartbeatToken(token string) (models.Settings, err
 
 func (s SettingsService) Save(userID string, req models.Settings) error {
 	req.WebhookURL = strings.TrimSpace(req.WebhookURL)
+	req.TelegramBotToken = strings.TrimSpace(req.TelegramBotToken)
+	req.TelegramChatID = strings.TrimSpace(req.TelegramChatID)
 	if req.WebhookEnabled && req.WebhookURL == "" {
 		return BadRequest("Webhook URL is required", nil)
 	}
@@ -78,6 +87,13 @@ func (s SettingsService) Save(userID string, req models.Settings) error {
 		}
 		req.WebhookSecret = encrypted
 	}
+	if req.TelegramBotToken != "" {
+		encrypted, err := cryptoService.EncryptIfNeeded(req.TelegramBotToken)
+		if err != nil {
+			return err
+		}
+		req.TelegramBotToken = encrypted
+	}
 
 	req.UserID = userID
 
@@ -85,6 +101,14 @@ func (s SettingsService) Save(userID string, req models.Settings) error {
 	result := database.DB.Where("user_id = ?", userID).First(&existing)
 	if result.Error != nil {
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			if req.TelegramEnabled {
+				if req.TelegramBotToken == "" {
+					return BadRequest("Telegram bot token is required when Telegram reminders are enabled", nil)
+				}
+				if req.TelegramChatID == "" {
+					return BadRequest("Telegram chat ID is required when Telegram reminders are enabled", nil)
+				}
+			}
 			if err := database.DB.Create(&req).Error; err != nil {
 				return Internal("Failed to save settings", err)
 			}
@@ -106,6 +130,19 @@ func (s SettingsService) Save(userID string, req models.Settings) error {
 		existing.WebhookSecret = req.WebhookSecret
 	}
 	existing.WebhookEnabled = req.WebhookEnabled
+	if req.TelegramEnabled {
+		if req.TelegramChatID == "" {
+			return BadRequest("Telegram chat ID is required when Telegram reminders are enabled", nil)
+		}
+		if req.TelegramBotToken == "" && existing.TelegramBotToken == "" {
+			return BadRequest("Telegram bot token is required when Telegram reminders are enabled", nil)
+		}
+	}
+	if req.TelegramBotToken != "" {
+		existing.TelegramBotToken = req.TelegramBotToken
+	}
+	existing.TelegramChatID = req.TelegramChatID
+	existing.TelegramEnabled = req.TelegramEnabled
 	existing.OwnerEmail = req.OwnerEmail
 
 	if err := database.DB.Save(&existing).Error; err != nil {
@@ -113,6 +150,38 @@ func (s SettingsService) Save(userID string, req models.Settings) error {
 	}
 
 	return nil
+}
+
+func (s SettingsService) TestTelegram(userID string, req models.Settings) error {
+	current, err := s.Get(userID)
+	if err != nil {
+		return err
+	}
+
+	botToken := strings.TrimSpace(req.TelegramBotToken)
+	if botToken == "" {
+		botToken = strings.TrimSpace(current.TelegramBotToken)
+	}
+	chatID := strings.TrimSpace(req.TelegramChatID)
+	if chatID == "" {
+		chatID = strings.TrimSpace(current.TelegramChatID)
+	}
+	if botToken == "" {
+		return BadRequest("Telegram bot token is required for test", nil)
+	}
+	if chatID == "" {
+		return BadRequest("Telegram chat ID is required for test", nil)
+	}
+	if strings.TrimSpace(current.HeartbeatToken) == "" {
+		return Internal("Heartbeat token is not configured for this account", nil)
+	}
+
+	testSettings := current
+	testSettings.TelegramBotToken = botToken
+	testSettings.TelegramChatID = chatID
+
+	telegramService := TelegramService{}
+	return telegramService.SendTestHeartbeat(testSettings)
 }
 
 func (s SettingsService) TestSMTP(req models.Settings) error {

--- a/backend/internal/services/telegram_service.go
+++ b/backend/internal/services/telegram_service.go
@@ -1,0 +1,117 @@
+package services
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/alpyxn/aeterna/backend/internal/models"
+)
+
+type TelegramService struct{}
+
+type telegramSendMessageRequest struct {
+	ChatID                string               `json:"chat_id"`
+	Text                  string               `json:"text"`
+	ReplyMarkup           *telegramReplyMarkup `json:"reply_markup,omitempty"`
+	DisableWebPagePreview bool                 `json:"disable_web_page_preview,omitempty"`
+}
+
+type telegramReplyMarkup struct {
+	InlineKeyboard [][]telegramInlineButton `json:"inline_keyboard"`
+}
+
+type telegramInlineButton struct {
+	Text string `json:"text"`
+	URL  string `json:"url"`
+}
+
+type telegramAPIResponse struct {
+	OK          bool   `json:"ok"`
+	Description string `json:"description"`
+}
+
+func (s TelegramService) SendHeartbeatReminder(settings models.Settings, remainingStr, recipients string) error {
+	quickLink := BuildQuickHeartbeatURL(settings.HeartbeatToken, true)
+	text := fmt.Sprintf("Check-in required.\n\nYour scheduled message for %s will be sent in %s unless you confirm.\n\nTap the button below to send a heartbeat.", recipients, remainingStr)
+	return s.sendMessage(settings.TelegramBotToken, settings.TelegramChatID, text, "Send heartbeat", quickLink)
+}
+
+func (s TelegramService) SendTestHeartbeat(settings models.Settings) error {
+	quickLink := BuildQuickHeartbeatURL(settings.HeartbeatToken, true)
+	text := "Test message from Aeterna.\n\nTap the button below to send a heartbeat using your current account."
+	return s.sendMessage(settings.TelegramBotToken, settings.TelegramChatID, text, "Send heartbeat", quickLink)
+}
+
+func (s TelegramService) sendMessage(botToken, chatID, text, buttonText, buttonURL string) error {
+	botToken = strings.TrimSpace(botToken)
+	chatID = strings.TrimSpace(chatID)
+	if botToken == "" {
+		return BadRequest("Telegram bot token is required", nil)
+	}
+	if chatID == "" {
+		return BadRequest("Telegram chat ID is required", nil)
+	}
+
+	reqBody := telegramSendMessageRequest{
+		ChatID:                chatID,
+		Text:                  text,
+		DisableWebPagePreview: true,
+	}
+	if buttonText != "" && buttonURL != "" {
+		reqBody.ReplyMarkup = &telegramReplyMarkup{
+			InlineKeyboard: [][]telegramInlineButton{{
+				{Text: buttonText, URL: buttonURL},
+			}},
+		}
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return Internal("Failed to encode Telegram request", err)
+	}
+
+	apiBase := strings.TrimRight(os.Getenv("TELEGRAM_API_BASE"), "/")
+	if apiBase == "" {
+		apiBase = "https://api.telegram.org"
+	}
+	endpoint := fmt.Sprintf("%s/bot%s/sendMessage", apiBase, botToken)
+
+	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return Internal("Failed to create Telegram request", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return Internal("Telegram request failed", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		msg := strings.TrimSpace(string(respBody))
+		if msg == "" {
+			msg = resp.Status
+		}
+		return BadRequest("Telegram API returned non-2xx status", fmt.Errorf("%s", msg))
+	}
+
+	var apiResp telegramAPIResponse
+	if err := json.Unmarshal(respBody, &apiResp); err == nil && !apiResp.OK {
+		msg := strings.TrimSpace(apiResp.Description)
+		if msg == "" {
+			msg = "unknown Telegram API error"
+		}
+		return BadRequest("Telegram API rejected the request", fmt.Errorf("%s", msg))
+	}
+
+	return nil
+}

--- a/backend/internal/services/telegram_service_test.go
+++ b/backend/internal/services/telegram_service_test.go
@@ -1,0 +1,83 @@
+package services
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alpyxn/aeterna/backend/internal/models"
+)
+
+func TestTelegramServiceSendTestHeartbeat(t *testing.T) {
+	var gotPath string
+	var gotBody telegramSendMessageRequest
+	var decodeErr error
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		decodeErr = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	t.Setenv("TELEGRAM_API_BASE", server.URL)
+	t.Setenv("BASE_URL", "https://dead.example")
+
+	settings := models.Settings{
+		TelegramBotToken: "bot-token",
+		TelegramChatID:   "123456",
+		HeartbeatToken:   "heartbeat-token",
+	}
+
+	if err := (TelegramService{}).SendTestHeartbeat(settings); err != nil {
+		t.Fatalf("SendTestHeartbeat returned error: %v", err)
+	}
+	if decodeErr != nil {
+		t.Fatalf("decode request: %v", decodeErr)
+	}
+
+	if gotPath != "/botbot-token/sendMessage" {
+		t.Fatalf("unexpected path: %s", gotPath)
+	}
+	if gotBody.ChatID != "123456" {
+		t.Fatalf("expected chat_id 123456, got %q", gotBody.ChatID)
+	}
+	if gotBody.ReplyMarkup == nil || len(gotBody.ReplyMarkup.InlineKeyboard) != 1 || len(gotBody.ReplyMarkup.InlineKeyboard[0]) != 1 {
+		t.Fatalf("expected a single inline button, got %#v", gotBody.ReplyMarkup)
+	}
+	if gotBody.ReplyMarkup.InlineKeyboard[0][0].URL != "https://dead.example/api/quick-heartbeat/heartbeat-token?auto=1" {
+		t.Fatalf("unexpected button URL: %s", gotBody.ReplyMarkup.InlineKeyboard[0][0].URL)
+	}
+}
+
+func TestTelegramServiceRejectsAPILevelFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":false,"description":"chat not found"}`))
+	}))
+	defer server.Close()
+
+	t.Setenv("TELEGRAM_API_BASE", server.URL)
+	t.Setenv("BASE_URL", "https://dead.example")
+
+	settings := models.Settings{
+		TelegramBotToken: "bot-token",
+		TelegramChatID:   "123456",
+		HeartbeatToken:   "heartbeat-token",
+	}
+
+	err := (TelegramService{}).SendTestHeartbeat(settings)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected APIError, got %T", err)
+	}
+	if err.Error() != "Telegram API rejected the request: chat not found" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/backend/internal/worker/worker.go
+++ b/backend/internal/worker/worker.go
@@ -3,7 +3,6 @@ package worker
 import (
 	"fmt"
 	"log/slog"
-	"os"
 	"strings"
 	"time"
 
@@ -19,6 +18,7 @@ type Worker struct {
 	webhooks ports.WebhookStorePort
 	files    ports.FileServicePort
 	email    services.EmailService
+	telegram services.TelegramService
 	webhook  services.WebhookService
 }
 
@@ -69,15 +69,41 @@ func (w *Worker) checkReminders() {
 		if msg.UserID == "" {
 			continue
 		}
+
 		settings, err := w.settings.Get(msg.UserID)
-		if err != nil || settings.OwnerEmail == "" || settings.SMTPHost == "" {
+		if err != nil {
 			continue
 		}
-		w.sendReminderEmail(settings, msg, req)
+		if w.dispatchReminder(settings, msg, req) {
+			if err := database.DB.Model(&req).Update("sent", true).Error; err != nil {
+				slog.Error("Failed to mark reminder as sent", "error", err, "reminder_id", req.ID)
+			}
+		}
 	}
 }
 
-func (w *Worker) sendReminderEmail(settings models.Settings, msg models.Message, reminder models.MessageReminder) {
+func (w *Worker) dispatchReminder(settings models.Settings, msg models.Message, reminder models.MessageReminder) bool {
+	if settings.TelegramEnabled {
+		if err := w.sendReminderTelegram(settings, msg); err != nil {
+			slog.Error("Failed to send Telegram reminder", "error", err, "message_id", msg.ID, "chat_id", settings.TelegramChatID)
+		} else {
+			slog.Info("Telegram reminder sent", "message_id", msg.ID, "minutes_before", reminder.MinutesBefore)
+			return true
+		}
+	}
+
+	if settings.OwnerEmail == "" || settings.SMTPHost == "" {
+		return false
+	}
+	if err := w.sendReminderEmail(settings, msg); err != nil {
+		slog.Error("Failed to send reminder email", "error", err, "owner", settings.OwnerEmail)
+		return false
+	}
+	slog.Info("Reminder email sent", "owner", settings.OwnerEmail, "message_id", msg.ID, "minutes_before", reminder.MinutesBefore)
+	return true
+}
+
+func (w *Worker) sendReminderEmail(settings models.Settings, msg models.Message) error {
 	lastSeen := msg.LastSeen
 	triggerTime := lastSeen.Add(time.Duration(msg.TriggerDuration) * time.Minute)
 	remaining := time.Until(triggerTime)
@@ -92,11 +118,7 @@ func (w *Worker) sendReminderEmail(settings models.Settings, msg models.Message,
 		remainingStr = fmt.Sprintf("%.0f minute(s)", remaining.Minutes())
 	}
 
-	baseURL := os.Getenv("BASE_URL")
-	if baseURL == "" {
-		baseURL = "http://localhost:5173"
-	}
-	quickLink := fmt.Sprintf("%s/api/quick-heartbeat/%s", baseURL, settings.HeartbeatToken)
+	quickLink := services.BuildQuickHeartbeatURL(settings.HeartbeatToken, false)
 
 	subject := "Check-in required"
 	body := fmt.Sprintf(`You have a scheduled message that will be sent in %s unless you confirm.
@@ -109,16 +131,25 @@ To confirm you are available, click the link below:
 ---
 Sent by Aeterna`, remainingStr, formatRecipients(msg.RecipientEmail), quickLink)
 
-	err := w.email.SendPlain(settings, []string{settings.OwnerEmail}, subject, body)
-	if err != nil {
-		slog.Error("Failed to send reminder email", "error", err, "owner", settings.OwnerEmail)
-		return
+	return w.email.SendPlain(settings, []string{settings.OwnerEmail}, subject, body)
+}
+
+func (w *Worker) sendReminderTelegram(settings models.Settings, msg models.Message) error {
+	lastSeen := msg.LastSeen
+	triggerTime := lastSeen.Add(time.Duration(msg.TriggerDuration) * time.Minute)
+	remaining := time.Until(triggerTime)
+
+	var remainingStr string
+	if remaining.Hours() > 24 {
+		days := int(remaining.Hours() / 24)
+		remainingStr = fmt.Sprintf("%d day(s)", days)
+	} else if remaining.Hours() > 1 {
+		remainingStr = fmt.Sprintf("%.0f hour(s)", remaining.Hours())
+	} else {
+		remainingStr = fmt.Sprintf("%.0f minute(s)", remaining.Minutes())
 	}
 
-	if err := database.DB.Model(&reminder).Update("sent", true).Error; err != nil {
-		slog.Error("Failed to mark reminder as sent", "error", err, "reminder_id", reminder.ID)
-	}
-	slog.Info("Reminder email sent", "owner", settings.OwnerEmail, "message_id", msg.ID, "minutes_before", reminder.MinutesBefore)
+	return w.telegram.SendHeartbeatReminder(settings, remainingStr, formatRecipients(msg.RecipientEmail))
 }
 
 func (w *Worker) checkHeartbeats() {

--- a/docker-compose.proxy.yml
+++ b/docker-compose.proxy.yml
@@ -12,8 +12,8 @@ services:
     environment:
       - DATABASE_PATH=/app/data/aeterna.db
       - ENV=production
-      - ALLOWED_ORIGINS=https://${DOMAIN}
-      - BASE_URL=https://${DOMAIN}
+      - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-https://${DOMAIN}}
+      - BASE_URL=${BASE_URL:-https://${DOMAIN}}
       # Encryption key is provided via Docker secrets (mounted at /run/secrets/encryption_key)
 
     command: ["./main", "--encryption-key-file=/run/secrets/encryption_key"]

--- a/frontend/src/components/Settings.jsx
+++ b/frontend/src/components/Settings.jsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from "@/components/ui/card"
 import { Alert, AlertDescription } from "@/components/ui/alert"
-import { Mail, Server, Save, Loader2, CheckCircle, Eye, EyeOff, TestTube, ChevronDown, ChevronUp, ExternalLink, Trash2, UserPlus, AlertTriangle, Users, Shield } from 'lucide-react';
+import { Mail, Server, Save, Loader2, CheckCircle, Eye, EyeOff, TestTube, ChevronDown, ChevronUp, ExternalLink, Trash2, UserPlus, AlertTriangle, Users, Shield, MessageCircle } from 'lucide-react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog"
 import { apiRequest } from "@/lib/api";
 import {
@@ -86,17 +86,24 @@ export default function Settings() {
         smtp_from: '',
         smtp_from_name: 'Aeterna',
         owner_email: '',
+        telegram_bot_token: '',
+        telegram_chat_id: '',
+        telegram_enabled: false,
+        telegram_bot_configured: false,
         allow_registration: false,
         can_manage_registration: false,
     });
     const [configLoading, setConfigLoading] = useState(true);
     const [loading, setLoading] = useState(false);
     const [testLoading, setTestLoading] = useState(false);
-    /** Which settings card last saved successfully ('owner' | 'registration' | 'smtp'), or null */
+    /** Which settings card last saved successfully ('owner' | 'telegram' | 'registration' | 'smtp'), or null */
     const [savedSection, setSavedSection] = useState(null);
     const [testSuccess, setTestSuccess] = useState(false);
+    const [telegramTestLoading, setTelegramTestLoading] = useState(false);
+    const [telegramTestSuccess, setTelegramTestSuccess] = useState(false);
     const [error, setError] = useState(null);
     const [showPassword, setShowPassword] = useState(false);
+    const [showTelegramToken, setShowTelegramToken] = useState(false);
     const [webhooks, setWebhooks] = useState([]);
     const [webhookLoading, setWebhookLoading] = useState(false);
     const [showWebhookSecret, setShowWebhookSecret] = useState(false);
@@ -238,6 +245,13 @@ export default function Settings() {
                 method: 'POST',
                 body: JSON.stringify(config)
             });
+            if (section === 'telegram') {
+                setConfig(prev => ({
+                    ...prev,
+                    telegram_bot_token: '',
+                    telegram_bot_configured: prev.telegram_bot_configured || Boolean(prev.telegram_bot_token),
+                }));
+            }
             setSavedSection(section);
             setTimeout(() => setSavedSection((s) => (s === section ? null : s)), 3000);
             if (section === 'registration' && config.allow_registration) {
@@ -269,6 +283,24 @@ export default function Settings() {
             setError(e.message);
         } finally {
             setTestLoading(false);
+        }
+    };
+
+    const handleTestTelegram = async () => {
+        setTelegramTestLoading(true);
+        setError(null);
+        setTelegramTestSuccess(false);
+        try {
+            await apiRequest('/settings/telegram/test', {
+                method: 'POST',
+                body: JSON.stringify(config)
+            });
+            setTelegramTestSuccess(true);
+            setTimeout(() => setTelegramTestSuccess(false), 3000);
+        } catch (e) {
+            setError(e.message);
+        } finally {
+            setTelegramTestLoading(false);
         }
     };
 
@@ -408,6 +440,139 @@ export default function Settings() {
                             <Save className="w-3.5 h-3.5 mr-1.5" />
                         )}
                         Save Email
+                    </Button>
+                </CardFooter>
+            </Card>
+
+            <Card className="border-dark-700 bg-dark-900">
+                <CardHeader>
+                    <CardTitle className="flex items-center gap-2 text-base font-medium text-dark-100">
+                        <MessageCircle className="w-4 h-4 text-teal-400" />
+                        Telegram Heartbeat Reminders
+                    </CardTitle>
+                    <CardDescription className="text-dark-400">
+                        Send check-in reminders through a Telegram bot. When enabled, Aeterna will try Telegram first and fall back to email if Telegram delivery fails.
+                    </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                    <label className="flex items-start gap-3 cursor-pointer group">
+                        <input
+                            type="checkbox"
+                            className="mt-1 h-4 w-4 rounded border-dark-600 bg-dark-950 text-teal-600 focus:ring-teal-500 focus:ring-offset-0"
+                            checked={Boolean(config.telegram_enabled)}
+                            onChange={(e) => {
+                                setConfig({ ...config, telegram_enabled: e.target.checked });
+                                if (error) setError(null);
+                                setSavedSection(null);
+                                if (telegramTestSuccess) setTelegramTestSuccess(false);
+                            }}
+                        />
+                        <span className="text-sm text-dark-200">
+                            Enable Telegram reminders for heartbeat check-ins
+                        </span>
+                    </label>
+
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div className="space-y-2">
+                            <label className="text-xs font-bold text-dark-500 uppercase tracking-wider">
+                                Bot Token
+                            </label>
+                            <div className="relative">
+                                <Input
+                                    type={showTelegramToken ? "text" : "password"}
+                                    placeholder={config.telegram_bot_configured ? "Saved token hidden; enter a new one to replace it" : "123456789:AA..."}
+                                    value={config.telegram_bot_token || ''}
+                                    onChange={(e) => {
+                                        setConfig({ ...config, telegram_bot_token: e.target.value });
+                                        if (error) setError(null);
+                                        setSavedSection(null);
+                                        if (telegramTestSuccess) setTelegramTestSuccess(false);
+                                    }}
+                                    className="bg-dark-950 border-dark-800 pr-10"
+                                    aria-invalid={Boolean(error)}
+                                />
+                                <button
+                                    type="button"
+                                    onClick={() => setShowTelegramToken(!showTelegramToken)}
+                                    className="absolute right-3 top-1/2 -translate-y-1/2 text-dark-500 hover:text-dark-300"
+                                >
+                                    {showTelegramToken ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                                </button>
+                            </div>
+                            <p className="text-xs text-dark-500">
+                                {config.telegram_bot_configured ? 'A token is already stored. Leave this blank to keep it.' : 'Create a Telegram bot with BotFather and paste the token here.'}
+                            </p>
+                        </div>
+                        <div className="space-y-2">
+                            <label className="text-xs font-bold text-dark-500 uppercase tracking-wider">
+                                Chat ID
+                            </label>
+                            <Input
+                                placeholder="123456789"
+                                value={config.telegram_chat_id || ''}
+                                onChange={(e) => {
+                                    setConfig({ ...config, telegram_chat_id: e.target.value });
+                                    if (error) setError(null);
+                                    setSavedSection(null);
+                                    if (telegramTestSuccess) setTelegramTestSuccess(false);
+                                }}
+                                className="bg-dark-950 border-dark-800"
+                                aria-invalid={Boolean(error)}
+                            />
+                            <p className="text-xs text-dark-500">
+                                Use your private chat ID with the bot. The Telegram button opens Aeterna and confirms the heartbeat automatically.
+                            </p>
+                        </div>
+                    </div>
+
+                    {savedSection === 'telegram' && (
+                        <Alert className="border-green-500/30 bg-green-500/10">
+                            <CheckCircle className="h-4 w-4 text-green-400" />
+                            <AlertDescription className="text-green-400">
+                                Telegram settings saved successfully!
+                            </AlertDescription>
+                        </Alert>
+                    )}
+
+                    {telegramTestSuccess && (
+                        <Alert className="border-green-500/30 bg-green-500/10">
+                            <CheckCircle className="h-4 w-4 text-green-400" />
+                            <AlertDescription className="text-green-400">
+                                Telegram test message sent successfully!
+                            </AlertDescription>
+                        </Alert>
+                    )}
+                </CardContent>
+                <CardFooter className="flex flex-col sm:flex-row gap-2">
+                    <Button
+                        variant="outline"
+                        className="border-dark-700 hover:bg-dark-800"
+                        onClick={handleTestTelegram}
+                        disabled={
+                            telegramTestLoading ||
+                            configLoading ||
+                            !config.telegram_chat_id ||
+                            (!config.telegram_bot_token && !config.telegram_bot_configured)
+                        }
+                    >
+                        {telegramTestLoading ? (
+                            <Loader2 className="w-4 h-4 animate-spin mr-2" />
+                        ) : (
+                            <TestTube className="w-4 h-4 mr-2" />
+                        )}
+                        Send Test Message
+                    </Button>
+                    <Button
+                        className="flex-1 bg-teal-600 hover:bg-teal-500"
+                        onClick={() => handleSave('telegram')}
+                        disabled={loading || configLoading}
+                    >
+                        {loading ? (
+                            <Loader2 className="w-4 h-4 animate-spin mr-2" />
+                        ) : (
+                            <Save className="w-4 h-4 mr-2" />
+                        )}
+                        Save Telegram
                     </Button>
                 </CardFooter>
             </Card>


### PR DESCRIPTION
## Summary

- Add Telegram heartbeat reminder feature to notify users periodically via Telegram
- Allow overriding `ALLOWED_ORIGINS` and `BASE_URL` in the proxy Docker Compose config via environment variables (with `https://${DOMAIN}` as default fallback)

## Test plan

- [ ] Configure Telegram bot token and test heartbeat reminders are sent at the expected interval
- [ ] Deploy with proxy config and verify `ALLOWED_ORIGINS` / `BASE_URL` can be overridden via env vars
- [ ] Verify default behavior (using `${DOMAIN}`) still works when override vars are not set