### PR TITLE
refactor(backend): centralize runtime config and inject sections

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -3,9 +3,9 @@ package main
 import (
 	"flag"
 	"log"
-	"os"
 	"time"
 
+	"github.com/alpyxn/aeterna/backend/internal/config"
 	"github.com/alpyxn/aeterna/backend/internal/database"
 	"github.com/alpyxn/aeterna/backend/internal/handlers"
 	"github.com/alpyxn/aeterna/backend/internal/logging"
@@ -24,8 +24,9 @@ import (
 func main() {
 	encryptionKeyFile := flag.String("encryption-key-file", "", "Path to file containing encryption key (fallback, must have 0600 permissions)")
 	flag.Parse()
+	cfg := config.Load()
 
-	logging.Init()
+	logging.Init(cfg)
 
 	services.InitKeyManager(*encryptionKeyFile)
 
@@ -39,19 +40,8 @@ func main() {
 			"\n"+
 			"For more information, see: https://github.com/alpyxn/aeterna/blob/main/README.md", err)
 	}
-	if os.Getenv("ENV") == "production" {
-		if os.Getenv("DATABASE_PATH") == "" {
-			log.Fatal("DATABASE_PATH must be set in production")
-		}
-		if os.Getenv("ALLOWED_ORIGINS") == "" {
-			log.Fatal("ALLOWED_ORIGINS must be set in production")
-		}
-		if os.Getenv("ALLOWED_ORIGINS") == "*" && os.Getenv("PROXY_MODE") != "simple" {
-			log.Fatal("ALLOWED_ORIGINS cannot be '*' in production (unless using simple mode)")
-		}
-	}
 
-	database.Connect()
+	database.Connect(cfg)
 
 	if err := database.DB.AutoMigrate(
 		&models.User{},
@@ -67,7 +57,7 @@ func main() {
 		log.Fatal("Failed to migrate database: ", err)
 	}
 
-	if err := database.MigrateLegacyToMultitenant(database.DB); err != nil {
+	if err := database.MigrateLegacyToMultitenant(database.DB, cfg); err != nil {
 		log.Fatal("Failed to migrate to multi-tenant schema: ", err)
 	}
 
@@ -87,22 +77,24 @@ func main() {
 	database.DB.Exec("UPDATE messages SET encrypted_content = '' WHERE encrypted_content IS NULL;")
 	database.DB.Exec("UPDATE settings SET webhook_enabled = 0 WHERE webhook_enabled IS NULL;")
 
-	if err := services.EnsureUploadsDir(); err != nil {
+	if err := services.EnsureUploadsDir(cfg.Database.Path); err != nil {
 		log.Fatal("Failed to create uploads directory: ", err)
 	}
 
+	handlers.SetIsProduction(cfg)
+
 	// --- Composition root: wire services ---
-	authSvc := services.AuthService{}
+	authSvc := services.NewAuthService(cfg)
 	messageSvc := services.MessageService{}
-	fileSvc := services.FileService{}
+	fileSvc := services.NewFileService(cfg)
 	farewellSvc := services.FarewellService{}
-	settingsSvc := services.SettingsService{}
+	settingsSvc := services.NewSettingsService(cfg)
 	appSettingsSvc := services.ApplicationSettingsService{}
-	webhookStore := services.WebhookStore{}
-	userAdminSvc := services.UserAdminService{}
+	webhookStore := services.NewWebhookStore(cfg)
+	userAdminSvc := services.NewUserAdminService(cfg)
 
 	// --- Wire handlers ---
-	authH := handlers.NewAuthHandlers(authSvc)
+	authH := handlers.NewAuthHandlers(authSvc, cfg)
 	messageH := handlers.NewMessageHandlers(messageSvc)
 	heartbeatH := handlers.NewHeartbeatHandlers(messageSvc, settingsSvc)
 	attachH := handlers.NewAttachmentHandlers(fileSvc)
@@ -112,7 +104,7 @@ func main() {
 	usersH := handlers.NewUserHandlers(userAdminSvc)
 
 	// --- Wire worker ---
-	w := worker.New(settingsSvc, webhookStore, fileSvc)
+	w := worker.New(settingsSvc, webhookStore, fileSvc, cfg)
 
 	app := fiber.New(fiber.Config{
 		BodyLimit: 25 * 1024 * 1024,
@@ -122,12 +114,9 @@ func main() {
 	app.Use(logger.New(logger.Config{
 		Format: "{\"time\":\"${time}\",\"ip\":\"${ip}\",\"status\":${status},\"method\":\"${method}\",\"path\":\"${path}\",\"latency\":\"${latency}\",\"req_id\":\"${locals:requestid}\"}\n",
 	}))
-	app.Use(middleware.SecurityHeaders)
+	app.Use(middleware.SecurityHeaders(cfg))
 
-	allowedOrigins := os.Getenv("ALLOWED_ORIGINS")
-	if allowedOrigins == "" {
-		allowedOrigins = "http://localhost:5173"
-	}
+	allowedOrigins := cfg.AllowedOriginsOrDefault()
 
 	if allowedOrigins == "*" {
 		app.Use(cors.New(cors.Config{
@@ -175,7 +164,7 @@ func main() {
 	api.Post("/quick-heartbeat/:token", heartbeatH.QuickHeartbeat)
 
 	// Protected routes
-	mgmt := api.Group("/", middleware.MasterAuth)
+	mgmt := api.Group("/", middleware.MasterAuth(authSvc, cfg))
 	mgmt.Post("/messages", messageH.Create)
 	mgmt.Get("/messages", messageH.List)
 	mgmt.Delete("/messages/:id", messageH.Delete)

--- a/backend/docs/config-service.md
+++ b/backend/docs/config-service.md
@@ -1,0 +1,145 @@
+# Backend Config Service
+
+## Purpose
+
+The config service centralizes backend environment loading and validation in one place.
+It is loaded once at startup (`config.Load()`), then injected into services, middleware, logging, database, and worker components.
+
+## What Changed
+
+A new config layer was added under `backend/internal/config/` with section-based modules:
+
+- `app`
+- `database`
+- `http`
+- `auth`
+- `logging`
+- `worker`
+- `webhook`
+
+Several components were updated to receive `config.Config` via dependency injection instead of reading `os.Getenv` directly:
+
+- `database.Connect`
+- `database.MigrateLegacyToMultitenant`
+- `logging.Init`
+- `middleware.MasterAuth`
+- `middleware.SecurityHeaders`
+- `handlers.SetIsProduction`
+- `handlers.NewAuthHandlers`
+- `services.NewAuthService`
+- `services.NewFileService`
+- `services.NewSettingsService`
+- `services.NewWebhookStore`
+- `services.NewUserAdminService`
+- `worker.New`
+
+## Load Flow
+
+```mermaid
+flowchart TD
+    A[main.go] --> B[config.Load]
+    B --> C[Discover registered modules]
+    C --> D[LoadAndValidate per module]
+    D --> E{Validation error?}
+    E -->|Yes| F[panic: startup blocked]
+    E -->|No| G[Build typed config.Config]
+    G --> H[Inject into DB, logging, middleware, services, worker]
+```
+
+```mermaid
+sequenceDiagram
+    participant Main as cmd/server/main.go
+    participant CFG as internal/config
+    participant DB as internal/database
+    participant LOG as internal/logging
+    participant MW as internal/middleware
+    participant SVC as internal/services
+    participant W as internal/worker
+
+    Main->>CFG: Load()
+    CFG-->>Main: Config
+    Main->>LOG: Init(cfg)
+    Main->>DB: Connect(cfg)
+    Main->>SVC: NewAuthService(cfg), NewFileService(cfg), ...
+    Main->>MW: SecurityHeaders(cfg), MasterAuth(authSvc, cfg)
+    Main->>W: New(..., cfg)
+```
+
+## Configuration Sections
+
+| Section | Variables |
+|---|---|
+| `app` | `ENV` |
+| `database` | `DATABASE_PATH`, `DB_HOST`, `POSTGRES_HOST`, `DATABASE_URL` |
+| `http` | `ALLOWED_ORIGINS`, `PROXY_MODE` |
+| `auth` | `AUTH_SESSION_TTL_HOURS`, `ALLOW_REGISTRATION`, `MASTER_PASSWORD`, `AUTH_COOKIE_SECURE_MODE` |
+| `logging` | `LOG_LEVEL`, `LOG_FORMAT`, `LOG_FILE`, `LOG_MAX_SIZE`, `LOG_MAX_BACKUPS`, `LOG_MAX_AGE`, `LOG_COMPRESS` |
+| `worker` | `BASE_URL` |
+| `webhook` | `WEBHOOK_ALLOWLIST_HOSTS` |
+
+Production validations:
+
+- `DATABASE_PATH` is required when `ENV=production`.
+- `ALLOWED_ORIGINS` is required when `ENV=production`.
+- `ALLOWED_ORIGINS=*` is blocked in production unless `PROXY_MODE=simple`.
+
+## How to Use
+
+In `main.go`:
+
+```go
+cfg := config.Load()
+```
+
+Typical injection:
+
+```go
+authSvc := services.NewAuthService(cfg)
+settingsSvc := services.NewSettingsService(cfg)
+webhookStore := services.NewWebhookStore(cfg)
+
+app.Use(middleware.SecurityHeaders(cfg))
+mgmt := api.Group("/", middleware.MasterAuth(authSvc, cfg))
+```
+
+Runtime examples:
+
+- `cfg.Database.Path` for SQLite path and upload paths.
+- `cfg.Auth.SessionTTLHours` for session expiration.
+- `cfg.Auth.CookieSecureMode` for secure cookie policy.
+- `cfg.Worker.BaseURL` for quick-heartbeat links.
+- `cfg.Webhook.AllowlistHosts` for webhook destination validation.
+- `cfg.Logging.*` for level/format/rotation.
+
+Convenience helpers:
+
+- `cfg.IsProduction()`
+- `cfg.AllowedOriginsOrDefault()`
+
+## How to Extend
+
+To add a new config section:
+
+1. Create a module in `backend/internal/config/services/<name>_service.go`.
+2. Implement `Name()`, `Section()`, and `LoadAndValidate()`.
+3. Register the module with `common.Register(...)` in `init()`.
+4. Add the section field to `Config` in `backend/internal/config/types.go` with `config:"<section>"`.
+5. Add unit tests for the module and expected behavior.
+
+Rule of thumb: if the section is critical in production, validate it in the module and return an error so startup is blocked.
+
+## Common Errors
+
+- Startup panic: usually a missing required variable in production.
+- Unmapped section: `Section()` name does not match the `config:"..."` tag in `Config`.
+- Type mismatch: `LoadAndValidate()` return type does not match the `Config` field type.
+- Duplicate registration: two modules declare the same `Section()`.
+
+## Why This Is Better
+
+It removes configuration sprawl. Before this, defaults and parsing rules could diverge across packages.
+Now there is a single typed contract.
+
+It also fails early. Invalid runtime config is detected at boot, not during live requests.
+
+Finally, it improves maintainability and testing. Each section is unit-tested, and the full loader behavior is tested end to end.

--- a/backend/internal/config/common/contracts.go
+++ b/backend/internal/config/common/contracts.go
@@ -1,0 +1,45 @@
+package common
+
+type Module[T any] interface {
+	Name() string
+	Section() string
+	LoadAndValidate() (T, error)
+}
+
+type RuntimeModule interface {
+	Name() string
+	Section() string
+	LoadAndValidateAny() (any, error)
+}
+
+type runtimeModule[T any] struct {
+	module Module[T]
+}
+
+var modules []RuntimeModule
+
+func Register[T any](module Module[T]) {
+	modules = append(modules, runtimeModule[T]{module: module})
+}
+
+func RegisteredModules() []RuntimeModule {
+	out := make([]RuntimeModule, len(modules))
+	copy(out, modules)
+	return out
+}
+
+func (r runtimeModule[T]) Name() string {
+	return r.module.Name()
+}
+
+func (r runtimeModule[T]) Section() string {
+	return r.module.Section()
+}
+
+func (r runtimeModule[T]) LoadAndValidateAny() (any, error) {
+	section, err := r.module.LoadAndValidate()
+	if err != nil {
+		return nil, err
+	}
+	return section, nil
+}

--- a/backend/internal/config/common/defaults.go
+++ b/backend/internal/config/common/defaults.go
@@ -1,0 +1,12 @@
+package common
+
+const (
+	DefaultDatabasePath    = "./data/aeterna.db"
+	DefaultAllowedOrigins  = "http://localhost:5173"
+	DefaultWorkerBaseURL   = "http://localhost:5173"
+	DefaultSessionTTLHours = 12
+	DefaultLogMaxSize      = 50
+	DefaultLogMaxBackups   = 5
+	DefaultLogMaxAge       = 14
+	DefaultLogCompress     = true
+)

--- a/backend/internal/config/common/helpers.go
+++ b/backend/internal/config/common/helpers.go
@@ -1,0 +1,54 @@
+package common
+
+import (
+	"os"
+	"strconv"
+	"strings"
+)
+
+func GetenvTrim(key string) string {
+	return strings.TrimSpace(os.Getenv(key))
+}
+
+func WithDefault(value, fallback string) string {
+	if value == "" {
+		return fallback
+	}
+	return value
+}
+
+func GetInt(key string, fallback int) int {
+	val := GetenvTrim(key)
+	if val == "" {
+		return fallback
+	}
+	parsed, err := strconv.Atoi(val)
+	if err != nil {
+		return fallback
+	}
+	return parsed
+}
+
+func GetPositiveInt(key string, fallback int) int {
+	val := GetenvTrim(key)
+	if val == "" {
+		return fallback
+	}
+	parsed, err := strconv.Atoi(val)
+	if err != nil || parsed <= 0 {
+		return fallback
+	}
+	return parsed
+}
+
+func GetBool(key string, fallback bool) bool {
+	val := GetenvTrim(key)
+	if val == "" {
+		return fallback
+	}
+	parsed, err := strconv.ParseBool(val)
+	if err != nil {
+		return fallback
+	}
+	return parsed
+}

--- a/backend/internal/config/common/helpers_test.go
+++ b/backend/internal/config/common/helpers_test.go
@@ -1,0 +1,155 @@
+package common
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestGetenvTrim(t *testing.T) {
+	t.Run("unset key returns empty", func(t *testing.T) {
+		if got := GetenvTrim("_TEST_GETENVTRIM_NEVER_SET_XYZ"); got != "" {
+			t.Fatalf("expected empty string, got %q", got)
+		}
+	})
+
+	tests := []struct {
+		value string
+		want  string
+	}{
+		{"hello", "hello"},
+		{"  hello", "hello"},
+		{"hello  ", "hello"},
+		{"  hello  ", "hello"},
+		{"\thello\t", "hello"},
+		{"hello\n", "hello"},
+		{"  hello world  ", "hello world"},
+	}
+	for i, tc := range tests {
+		tc := tc
+		t.Run(fmt.Sprintf("trim_case_%d", i), func(t *testing.T) {
+			key := fmt.Sprintf("_TEST_GETENVTRIM_%d", i)
+			t.Setenv(key, tc.value)
+			got := GetenvTrim(key)
+			if got != tc.want {
+				t.Fatalf("input %q: got %q, want %q", tc.value, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWithDefault(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		fallback string
+		want     string
+	}{
+		{"empty uses fallback", "", "default", "default"},
+		{"non-empty uses value", "custom", "default", "custom"},
+		{"spaces not trimmed", "  x  ", "default", "  x  "},
+		{"fallback not used when value set", "val", "fb", "val"},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := WithDefault(tc.value, tc.fallback)
+			if got != tc.want {
+				t.Fatalf("WithDefault(%q, %q) = %q, want %q", tc.value, tc.fallback, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetInt(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		set      bool
+		fallback int
+		want     int
+	}{
+		{"unset uses fallback", "", false, 42, 42},
+		{"valid positive", "100", true, 0, 100},
+		{"valid zero", "0", true, 99, 0},
+		{"valid negative", "-5", true, 0, -5},
+		{"invalid string uses fallback", "abc", true, 7, 7},
+		{"float string uses fallback", "3.14", true, 8, 8},
+	}
+	for i, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			key := fmt.Sprintf("_TEST_GETINT_%d", i)
+			if tc.set {
+				t.Setenv(key, tc.value)
+			}
+			got := GetInt(key, tc.fallback)
+			if got != tc.want {
+				t.Fatalf("GetInt(value=%q, fallback=%d) = %d, want %d", tc.value, tc.fallback, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetPositiveInt(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		set      bool
+		fallback int
+		want     int
+	}{
+		{"unset uses fallback", "", false, 5, 5},
+		{"positive value", "10", true, 5, 10},
+		{"zero uses fallback", "0", true, 5, 5},
+		{"negative uses fallback", "-1", true, 5, 5},
+		{"invalid string uses fallback", "bad", true, 5, 5},
+		{"one is valid", "1", true, 5, 1},
+	}
+	for i, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			key := fmt.Sprintf("_TEST_GETPOSINT_%d", i)
+			if tc.set {
+				t.Setenv(key, tc.value)
+			}
+			got := GetPositiveInt(key, tc.fallback)
+			if got != tc.want {
+				t.Fatalf("GetPositiveInt(value=%q, fallback=%d) = %d, want %d", tc.value, tc.fallback, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetBool(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		set      bool
+		fallback bool
+		want     bool
+	}{
+		{"unset uses false fallback", "", false, false, false},
+		{"unset uses true fallback", "", false, true, true},
+		{"true", "true", true, false, true},
+		{"false", "false", true, true, false},
+		{"1", "1", true, false, true},
+		{"0", "0", true, true, false},
+		{"TRUE uppercase", "TRUE", true, false, true},
+		{"FALSE uppercase", "FALSE", true, true, false},
+		{"invalid uses fallback", "yes", true, false, false},
+		{"empty value uses fallback", "", true, true, true},
+	}
+	for i, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			key := fmt.Sprintf("_TEST_GETBOOL_%d", i)
+			if tc.set {
+				t.Setenv(key, tc.value)
+			}
+			got := GetBool(key, tc.fallback)
+			if got != tc.want {
+				t.Fatalf("GetBool(value=%q, fallback=%v) = %v, want %v", tc.value, tc.fallback, got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -1,0 +1,128 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/alpyxn/aeterna/backend/internal/config/common"
+	"github.com/alpyxn/aeterna/backend/internal/config/services"
+)
+
+func TestConfig_IsProduction(t *testing.T) {
+	tests := []struct {
+		env  string
+		want bool
+	}{
+		{"production", true},
+		{"development", false},
+		{"", false},
+		{"staging", false},
+		{"PRODUCTION", false},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(fmt.Sprintf("env=%q", tc.env), func(t *testing.T) {
+			cfg := Config{App: services.AppSection{Env: tc.env}}
+			if got := cfg.IsProduction(); got != tc.want {
+				t.Fatalf("IsProduction() = %v, want %v (env=%q)", got, tc.want, tc.env)
+			}
+		})
+	}
+}
+
+func TestConfig_AllowedOriginsOrDefault(t *testing.T) {
+	t.Run("empty AllowedOrigins uses default", func(t *testing.T) {
+		cfg := Config{HTTP: services.HTTPSection{AllowedOrigins: ""}}
+		got := cfg.AllowedOriginsOrDefault()
+		if got != common.DefaultAllowedOrigins {
+			t.Fatalf("got %q, want default %q", got, common.DefaultAllowedOrigins)
+		}
+	})
+
+	t.Run("non-empty AllowedOrigins returns configured value", func(t *testing.T) {
+		cfg := Config{HTTP: services.HTTPSection{AllowedOrigins: "https://example.com"}}
+		got := cfg.AllowedOriginsOrDefault()
+		if got != "https://example.com" {
+			t.Fatalf("got %q, want %q", got, "https://example.com")
+		}
+	})
+
+	t.Run("multiple origins returned as-is", func(t *testing.T) {
+		origins := "https://app.example.com,https://admin.example.com"
+		cfg := Config{HTTP: services.HTTPSection{AllowedOrigins: origins}}
+		got := cfg.AllowedOriginsOrDefault()
+		if got != origins {
+			t.Fatalf("got %q, want %q", got, origins)
+		}
+	})
+}
+
+func mustPanic(t *testing.T, fn func()) string {
+	t.Helper()
+	var msg string
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				msg = fmt.Sprintf("%v", r)
+			}
+		}()
+		fn()
+	}()
+	return msg
+}
+
+func TestLoad_DevelopmentMode(t *testing.T) {
+	t.Setenv("ENV", "")
+	t.Setenv("DATABASE_PATH", "")
+	t.Setenv("ALLOWED_ORIGINS", "")
+	t.Setenv("PROXY_MODE", "")
+
+	cfg := Load()
+
+	if cfg.IsProduction() {
+		t.Fatal("expected non-production config")
+	}
+	if cfg.Database.Path != common.DefaultDatabasePath {
+		t.Fatalf("Database.Path = %q, want %q", cfg.Database.Path, common.DefaultDatabasePath)
+	}
+	if cfg.Auth.SessionTTLHours != common.DefaultSessionTTLHours {
+		t.Fatalf("Auth.SessionTTLHours = %d, want %d", cfg.Auth.SessionTTLHours, common.DefaultSessionTTLHours)
+	}
+	if cfg.Worker.BaseURL != common.DefaultWorkerBaseURL {
+		t.Fatalf("Worker.BaseURL = %q, want %q", cfg.Worker.BaseURL, common.DefaultWorkerBaseURL)
+	}
+}
+
+func TestLoad_ProductionModePanicsWithoutRequiredVars(t *testing.T) {
+	t.Setenv("ENV", "production")
+	t.Setenv("DATABASE_PATH", "")
+	t.Setenv("ALLOWED_ORIGINS", "")
+
+	msg := mustPanic(t, func() { Load() })
+	if msg == "" {
+		t.Fatal("expected a panic but Load returned normally")
+	}
+	if !strings.Contains(msg, "config validation failed") {
+		t.Fatalf("unexpected panic message: %q", msg)
+	}
+}
+
+func TestLoad_ProductionModeWithAllRequiredVars(t *testing.T) {
+	t.Setenv("ENV", "production")
+	t.Setenv("DATABASE_PATH", "/prod/aeterna.db")
+	t.Setenv("ALLOWED_ORIGINS", "https://app.example.com")
+	t.Setenv("PROXY_MODE", "")
+
+	cfg := Load()
+
+	if !cfg.IsProduction() {
+		t.Fatal("expected production config")
+	}
+	if cfg.Database.Path != "/prod/aeterna.db" {
+		t.Fatalf("Database.Path = %q, want %q", cfg.Database.Path, "/prod/aeterna.db")
+	}
+	if cfg.HTTP.AllowedOrigins != "https://app.example.com" {
+		t.Fatalf("HTTP.AllowedOrigins = %q, want %q", cfg.HTTP.AllowedOrigins, "https://app.example.com")
+	}
+}

--- a/backend/internal/config/load.go
+++ b/backend/internal/config/load.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/alpyxn/aeterna/backend/internal/config/common"
+)
+
+func Load() Config {
+	var cfg Config
+	cfgValue := reflect.ValueOf(&cfg).Elem()
+	cfgType := cfgValue.Type()
+	sectionFields := make(map[string]reflect.Value, cfgType.NumField())
+	for i := 0; i < cfgType.NumField(); i++ {
+		fieldType := cfgType.Field(i)
+		section := fieldType.Tag.Get("config")
+		if section == "" {
+			continue
+		}
+		sectionFields[section] = cfgValue.Field(i)
+	}
+
+	loaders := common.RegisteredModules()
+	if len(loaders) == 0 {
+		panic("no config modules registered")
+	}
+
+	loadedSections := make(map[string]string, len(loaders))
+	for _, loader := range loaders {
+		if previousModule, alreadyLoaded := loadedSections[loader.Section()]; alreadyLoaded {
+			panic(fmt.Sprintf("duplicate config section %q registered by %s and %s", loader.Section(), previousModule, loader.Name()))
+		}
+
+		loadedSection, err := loader.LoadAndValidateAny()
+		if err != nil {
+			panic(fmt.Sprintf("config validation failed in %s: %v", loader.Name(), err))
+		}
+
+		field, ok := sectionFields[loader.Section()]
+		if !ok {
+			panic(fmt.Sprintf("config section %q from %s is not mapped in config.Config", loader.Section(), loader.Name()))
+		}
+
+		loadedValue := reflect.ValueOf(loadedSection)
+		if !loadedValue.IsValid() {
+			panic(fmt.Sprintf("config section %q from %s returned an invalid value", loader.Section(), loader.Name()))
+		}
+		if !loadedValue.Type().AssignableTo(field.Type()) {
+			panic(fmt.Sprintf("config section %q type mismatch from %s: got %s, want %s", loader.Section(), loader.Name(), loadedValue.Type(), field.Type()))
+		}
+		field.Set(loadedValue)
+		loadedSections[loader.Section()] = loader.Name()
+	}
+
+	for section := range sectionFields {
+		if _, ok := loadedSections[section]; !ok {
+			panic(fmt.Sprintf("no config module registered for section %q", section))
+		}
+	}
+	return cfg
+}

--- a/backend/internal/config/services/app_service.go
+++ b/backend/internal/config/services/app_service.go
@@ -1,0 +1,26 @@
+package services
+
+import (
+	"github.com/alpyxn/aeterna/backend/internal/config/common"
+)
+
+type AppModule struct{}
+
+func (AppModule) Name() string { return "AppModule" }
+func (AppModule) Section() string {
+	return "app"
+}
+
+func init() {
+	common.Register(AppModule{})
+}
+
+type AppSection struct {
+	Env string
+}
+
+func (AppModule) LoadAndValidate() (AppSection, error) {
+	return AppSection{
+		Env: common.GetenvTrim("ENV"),
+	}, nil
+}

--- a/backend/internal/config/services/app_service_test.go
+++ b/backend/internal/config/services/app_service_test.go
@@ -1,0 +1,41 @@
+package services
+
+import (
+	"testing"
+)
+
+func TestAppModule_Metadata(t *testing.T) {
+	m := AppModule{}
+	if got := m.Name(); got != "AppModule" {
+		t.Fatalf("Name() = %q, want %q", got, "AppModule")
+	}
+	if got := m.Section(); got != "app" {
+		t.Fatalf("Section() = %q, want %q", got, "app")
+	}
+}
+
+func TestAppModule_LoadAndValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		envVal  string
+		wantEnv string
+	}{
+		{"unset ENV returns empty", "", ""},
+		{"development mode", "development", "development"},
+		{"production mode", "production", "production"},
+		{"custom value", "staging", "staging"},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("ENV", tc.envVal)
+			section, err := AppModule{}.LoadAndValidate()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if section.Env != tc.wantEnv {
+				t.Fatalf("Env = %q, want %q", section.Env, tc.wantEnv)
+			}
+		})
+	}
+}

--- a/backend/internal/config/services/auth_service.go
+++ b/backend/internal/config/services/auth_service.go
@@ -1,0 +1,42 @@
+package services
+
+import (
+	"os"
+	"strings"
+
+	"github.com/alpyxn/aeterna/backend/internal/config/common"
+)
+
+type AuthModule struct{}
+
+func (AuthModule) Name() string { return "AuthModule" }
+func (AuthModule) Section() string {
+	return "auth"
+}
+
+func init() {
+	common.Register(AuthModule{})
+}
+
+type AuthSection struct {
+	SessionTTLHours   int
+	AllowRegistration bool
+	MasterPassword    string
+	CookieSecureMode  string
+}
+
+func (AuthModule) LoadAndValidate() (AuthSection, error) {
+	cookieMode := strings.ToLower(common.GetenvTrim("AUTH_COOKIE_SECURE_MODE"))
+	switch cookieMode {
+	case "always", "never":
+	default:
+		cookieMode = ""
+	}
+
+	return AuthSection{
+		SessionTTLHours:   common.GetPositiveInt("AUTH_SESSION_TTL_HOURS", common.DefaultSessionTTLHours),
+		AllowRegistration: os.Getenv("ALLOW_REGISTRATION") == "true",
+		MasterPassword:    os.Getenv("MASTER_PASSWORD"),
+		CookieSecureMode:  cookieMode,
+	}, nil
+}

--- a/backend/internal/config/services/auth_service_test.go
+++ b/backend/internal/config/services/auth_service_test.go
@@ -1,0 +1,145 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/alpyxn/aeterna/backend/internal/config/common"
+)
+
+func TestAuthModule_Metadata(t *testing.T) {
+	m := AuthModule{}
+	if got := m.Name(); got != "AuthModule" {
+		t.Fatalf("Name() = %q, want %q", got, "AuthModule")
+	}
+	if got := m.Section(); got != "auth" {
+		t.Fatalf("Section() = %q, want %q", got, "auth")
+	}
+}
+
+func TestAuthModule_LoadAndValidate(t *testing.T) {
+	t.Run("defaults when no env vars set", func(t *testing.T) {
+		t.Setenv("AUTH_SESSION_TTL_HOURS", "")
+		t.Setenv("ALLOW_REGISTRATION", "")
+		t.Setenv("MASTER_PASSWORD", "")
+		t.Setenv("AUTH_COOKIE_SECURE_MODE", "")
+		section, err := AuthModule{}.LoadAndValidate()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if section.SessionTTLHours != common.DefaultSessionTTLHours {
+			t.Fatalf("SessionTTLHours = %d, want %d", section.SessionTTLHours, common.DefaultSessionTTLHours)
+		}
+		if section.AllowRegistration {
+			t.Fatal("AllowRegistration should default to false")
+		}
+		if section.MasterPassword != "" {
+			t.Fatalf("MasterPassword = %q, want empty", section.MasterPassword)
+		}
+		if section.CookieSecureMode != "" {
+			t.Fatalf("CookieSecureMode = %q, want empty", section.CookieSecureMode)
+		}
+	})
+
+	t.Run("custom session TTL", func(t *testing.T) {
+		t.Setenv("AUTH_SESSION_TTL_HOURS", "48")
+		section, err := AuthModule{}.LoadAndValidate()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if section.SessionTTLHours != 48 {
+			t.Fatalf("SessionTTLHours = %d, want 48", section.SessionTTLHours)
+		}
+	})
+
+	t.Run("zero TTL falls back to default", func(t *testing.T) {
+		t.Setenv("AUTH_SESSION_TTL_HOURS", "0")
+		section, err := AuthModule{}.LoadAndValidate()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if section.SessionTTLHours != common.DefaultSessionTTLHours {
+			t.Fatalf("SessionTTLHours = %d, want default %d", section.SessionTTLHours, common.DefaultSessionTTLHours)
+		}
+	})
+
+	t.Run("negative TTL falls back to default", func(t *testing.T) {
+		t.Setenv("AUTH_SESSION_TTL_HOURS", "-1")
+		section, err := AuthModule{}.LoadAndValidate()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if section.SessionTTLHours != common.DefaultSessionTTLHours {
+			t.Fatalf("SessionTTLHours = %d, want default %d", section.SessionTTLHours, common.DefaultSessionTTLHours)
+		}
+	})
+
+	t.Run("invalid TTL string falls back to default", func(t *testing.T) {
+		t.Setenv("AUTH_SESSION_TTL_HOURS", "not-a-number")
+		section, err := AuthModule{}.LoadAndValidate()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if section.SessionTTLHours != common.DefaultSessionTTLHours {
+			t.Fatalf("SessionTTLHours = %d, want default %d", section.SessionTTLHours, common.DefaultSessionTTLHours)
+		}
+	})
+
+	t.Run("ALLOW_REGISTRATION true enables registration", func(t *testing.T) {
+		t.Setenv("ALLOW_REGISTRATION", "true")
+		section, err := AuthModule{}.LoadAndValidate()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !section.AllowRegistration {
+			t.Fatal("AllowRegistration should be true")
+		}
+	})
+
+	t.Run("ALLOW_REGISTRATION non-true value disables registration", func(t *testing.T) {
+		t.Setenv("ALLOW_REGISTRATION", "1")
+		section, err := AuthModule{}.LoadAndValidate()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if section.AllowRegistration {
+			t.Fatal("AllowRegistration should be false for value '1' (only 'true' is accepted)")
+		}
+	})
+
+	t.Run("MASTER_PASSWORD is captured as-is", func(t *testing.T) {
+		t.Setenv("MASTER_PASSWORD", "s3cr3tP@ss!")
+		section, err := AuthModule{}.LoadAndValidate()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if section.MasterPassword != "s3cr3tP@ss!" {
+			t.Fatalf("MasterPassword = %q, want %q", section.MasterPassword, "s3cr3tP@ss!")
+		}
+	})
+
+	cookieModeTests := []struct {
+		name       string
+		input      string
+		wantMode   string
+	}{
+		{"always mode", "always", "always"},
+		{"never mode", "never", "never"},
+		{"always uppercase normalized", "ALWAYS", "always"},
+		{"never uppercase normalized", "NEVER", "never"},
+		{"invalid mode cleared", "sometimes", ""},
+		{"empty mode cleared", "", ""},
+	}
+	for _, tc := range cookieModeTests {
+		tc := tc
+		t.Run("cookie_mode_"+tc.name, func(t *testing.T) {
+			t.Setenv("AUTH_COOKIE_SECURE_MODE", tc.input)
+			section, err := AuthModule{}.LoadAndValidate()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if section.CookieSecureMode != tc.wantMode {
+				t.Fatalf("CookieSecureMode = %q, want %q", section.CookieSecureMode, tc.wantMode)
+			}
+		})
+	}
+}

--- a/backend/internal/config/services/database_service.go
+++ b/backend/internal/config/services/database_service.go
@@ -1,0 +1,43 @@
+package services
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/alpyxn/aeterna/backend/internal/config/common"
+)
+
+type DatabaseModule struct{}
+
+func (DatabaseModule) Name() string { return "DatabaseModule" }
+func (DatabaseModule) Section() string {
+	return "database"
+}
+
+func init() {
+	common.Register(DatabaseModule{})
+}
+
+type DatabaseSection struct {
+	Path      string
+	PathIsSet bool
+
+	DBHost       string
+	PostgresHost string
+	DatabaseURL  string
+}
+
+func (DatabaseModule) LoadAndValidate() (DatabaseSection, error) {
+	rawPath := os.Getenv("DATABASE_PATH")
+	section := DatabaseSection{
+		Path:         common.WithDefault(common.GetenvTrim("DATABASE_PATH"), common.DefaultDatabasePath),
+		PathIsSet:    rawPath != "",
+		DBHost:       common.GetenvTrim("DB_HOST"),
+		PostgresHost: common.GetenvTrim("POSTGRES_HOST"),
+		DatabaseURL:  common.GetenvTrim("DATABASE_URL"),
+	}
+	if common.GetenvTrim("ENV") == "production" && !section.PathIsSet {
+		return DatabaseSection{}, fmt.Errorf("DATABASE_PATH must be set in production")
+	}
+	return section, nil
+}

--- a/backend/internal/config/services/database_service_test.go
+++ b/backend/internal/config/services/database_service_test.go
@@ -1,0 +1,113 @@
+package services
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/alpyxn/aeterna/backend/internal/config/common"
+)
+
+func TestDatabaseModule_Metadata(t *testing.T) {
+	m := DatabaseModule{}
+	if got := m.Name(); got != "DatabaseModule" {
+		t.Fatalf("Name() = %q, want %q", got, "DatabaseModule")
+	}
+	if got := m.Section(); got != "database" {
+		t.Fatalf("Section() = %q, want %q", got, "database")
+	}
+}
+
+func TestDatabaseModule_LoadAndValidate(t *testing.T) {
+	t.Run("defaults in development mode", func(t *testing.T) {
+		t.Setenv("ENV", "")
+		t.Setenv("DATABASE_PATH", "")
+		section, err := DatabaseModule{}.LoadAndValidate()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if section.Path != common.DefaultDatabasePath {
+			t.Fatalf("Path = %q, want %q", section.Path, common.DefaultDatabasePath)
+		}
+		if section.PathIsSet {
+			t.Fatal("PathIsSet should be false when DATABASE_PATH is empty")
+		}
+	})
+
+	t.Run("custom DATABASE_PATH", func(t *testing.T) {
+		t.Setenv("ENV", "")
+		t.Setenv("DATABASE_PATH", "/data/custom.db")
+		section, err := DatabaseModule{}.LoadAndValidate()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if section.Path != "/data/custom.db" {
+			t.Fatalf("Path = %q, want %q", section.Path, "/data/custom.db")
+		}
+		if !section.PathIsSet {
+			t.Fatal("PathIsSet should be true when DATABASE_PATH is set")
+		}
+	})
+
+	t.Run("production requires DATABASE_PATH", func(t *testing.T) {
+		t.Setenv("ENV", "production")
+		t.Setenv("DATABASE_PATH", "")
+		_, err := DatabaseModule{}.LoadAndValidate()
+		if err == nil {
+			t.Fatal("expected error when DATABASE_PATH is unset in production")
+		}
+		if !strings.Contains(err.Error(), "DATABASE_PATH") {
+			t.Fatalf("error message should mention DATABASE_PATH, got: %v", err)
+		}
+	})
+
+	t.Run("production with DATABASE_PATH succeeds", func(t *testing.T) {
+		t.Setenv("ENV", "production")
+		t.Setenv("DATABASE_PATH", "/prod/aeterna.db")
+		section, err := DatabaseModule{}.LoadAndValidate()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if section.Path != "/prod/aeterna.db" {
+			t.Fatalf("Path = %q, want %q", section.Path, "/prod/aeterna.db")
+		}
+		if !section.PathIsSet {
+			t.Fatal("PathIsSet should be true")
+		}
+	})
+
+	t.Run("postgres env vars are captured but not used as path", func(t *testing.T) {
+		t.Setenv("ENV", "")
+		t.Setenv("DATABASE_PATH", "")
+		t.Setenv("DB_HOST", "pg.host")
+		t.Setenv("POSTGRES_HOST", "pg2.host")
+		t.Setenv("DATABASE_URL", "postgres://user:pass@host/db")
+		section, err := DatabaseModule{}.LoadAndValidate()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if section.DBHost != "pg.host" {
+			t.Fatalf("DBHost = %q, want %q", section.DBHost, "pg.host")
+		}
+		if section.PostgresHost != "pg2.host" {
+			t.Fatalf("PostgresHost = %q, want %q", section.PostgresHost, "pg2.host")
+		}
+		if section.DatabaseURL != "postgres://user:pass@host/db" {
+			t.Fatalf("DatabaseURL = %q, want %q", section.DatabaseURL, "postgres://user:pass@host/db")
+		}
+		if section.Path != common.DefaultDatabasePath {
+			t.Fatalf("Path should remain default, got %q", section.Path)
+		}
+	})
+
+	t.Run("DATABASE_PATH whitespace is trimmed", func(t *testing.T) {
+		t.Setenv("ENV", "")
+		t.Setenv("DATABASE_PATH", "  /data/trimmed.db  ")
+		section, err := DatabaseModule{}.LoadAndValidate()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if section.Path != "/data/trimmed.db" {
+			t.Fatalf("Path = %q, want trimmed %q", section.Path, "/data/trimmed.db")
+		}
+	})
+}

--- a/backend/internal/config/services/http_service.go
+++ b/backend/internal/config/services/http_service.go
@@ -1,0 +1,41 @@
+package services
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/alpyxn/aeterna/backend/internal/config/common"
+)
+
+type HTTPModule struct{}
+
+func (HTTPModule) Name() string { return "HTTPModule" }
+func (HTTPModule) Section() string {
+	return "http"
+}
+
+func init() {
+	common.Register(HTTPModule{})
+}
+
+type HTTPSection struct {
+	AllowedOrigins      string
+	AllowedOriginsIsSet bool
+	ProxyMode           string
+}
+
+func (HTTPModule) LoadAndValidate() (HTTPSection, error) {
+	rawAllowedOrigins := os.Getenv("ALLOWED_ORIGINS")
+	section := HTTPSection{
+		AllowedOrigins:      common.GetenvTrim("ALLOWED_ORIGINS"),
+		AllowedOriginsIsSet: rawAllowedOrigins != "",
+		ProxyMode:           common.GetenvTrim("PROXY_MODE"),
+	}
+	if common.GetenvTrim("ENV") == "production" && !section.AllowedOriginsIsSet {
+		return HTTPSection{}, fmt.Errorf("ALLOWED_ORIGINS must be set in production")
+	}
+	if common.GetenvTrim("ENV") == "production" && section.AllowedOrigins == "*" && section.ProxyMode != "simple" {
+		return HTTPSection{}, fmt.Errorf("ALLOWED_ORIGINS cannot be '*' in production (unless using simple mode)")
+	}
+	return section, nil
+}

--- a/backend/internal/config/services/http_service_test.go
+++ b/backend/internal/config/services/http_service_test.go
@@ -1,0 +1,118 @@
+package services
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHTTPModule_Metadata(t *testing.T) {
+	m := HTTPModule{}
+	if got := m.Name(); got != "HTTPModule" {
+		t.Fatalf("Name() = %q, want %q", got, "HTTPModule")
+	}
+	if got := m.Section(); got != "http" {
+		t.Fatalf("Section() = %q, want %q", got, "http")
+	}
+}
+
+func TestHTTPModule_LoadAndValidate(t *testing.T) {
+	t.Run("development mode with no env vars", func(t *testing.T) {
+		t.Setenv("ENV", "")
+		t.Setenv("ALLOWED_ORIGINS", "")
+		t.Setenv("PROXY_MODE", "")
+		section, err := HTTPModule{}.LoadAndValidate()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if section.AllowedOriginsIsSet {
+			t.Fatal("AllowedOriginsIsSet should be false when ALLOWED_ORIGINS is empty")
+		}
+		if section.AllowedOrigins != "" {
+			t.Fatalf("AllowedOrigins = %q, want empty", section.AllowedOrigins)
+		}
+	})
+
+	t.Run("custom ALLOWED_ORIGINS", func(t *testing.T) {
+		t.Setenv("ENV", "")
+		t.Setenv("ALLOWED_ORIGINS", "https://example.com")
+		t.Setenv("PROXY_MODE", "")
+		section, err := HTTPModule{}.LoadAndValidate()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if section.AllowedOrigins != "https://example.com" {
+			t.Fatalf("AllowedOrigins = %q, want %q", section.AllowedOrigins, "https://example.com")
+		}
+		if !section.AllowedOriginsIsSet {
+			t.Fatal("AllowedOriginsIsSet should be true")
+		}
+	})
+
+	t.Run("production requires ALLOWED_ORIGINS", func(t *testing.T) {
+		t.Setenv("ENV", "production")
+		t.Setenv("ALLOWED_ORIGINS", "")
+		t.Setenv("PROXY_MODE", "")
+		_, err := HTTPModule{}.LoadAndValidate()
+		if err == nil {
+			t.Fatal("expected error when ALLOWED_ORIGINS is unset in production")
+		}
+		if !strings.Contains(err.Error(), "ALLOWED_ORIGINS") {
+			t.Fatalf("error should mention ALLOWED_ORIGINS, got: %v", err)
+		}
+	})
+
+	t.Run("production with wildcard ALLOWED_ORIGINS fails without simple mode", func(t *testing.T) {
+		t.Setenv("ENV", "production")
+		t.Setenv("ALLOWED_ORIGINS", "*")
+		t.Setenv("PROXY_MODE", "")
+		_, err := HTTPModule{}.LoadAndValidate()
+		if err == nil {
+			t.Fatal("expected error for wildcard ALLOWED_ORIGINS in production without simple mode")
+		}
+		if !strings.Contains(err.Error(), "*") {
+			t.Fatalf("error should mention wildcard, got: %v", err)
+		}
+	})
+
+	t.Run("production with wildcard ALLOWED_ORIGINS and simple proxy mode succeeds", func(t *testing.T) {
+		t.Setenv("ENV", "production")
+		t.Setenv("ALLOWED_ORIGINS", "*")
+		t.Setenv("PROXY_MODE", "simple")
+		section, err := HTTPModule{}.LoadAndValidate()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if section.AllowedOrigins != "*" {
+			t.Fatalf("AllowedOrigins = %q, want %q", section.AllowedOrigins, "*")
+		}
+		if section.ProxyMode != "simple" {
+			t.Fatalf("ProxyMode = %q, want %q", section.ProxyMode, "simple")
+		}
+	})
+
+	t.Run("production with specific origins succeeds", func(t *testing.T) {
+		t.Setenv("ENV", "production")
+		t.Setenv("ALLOWED_ORIGINS", "https://app.example.com,https://admin.example.com")
+		t.Setenv("PROXY_MODE", "")
+		section, err := HTTPModule{}.LoadAndValidate()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !section.AllowedOriginsIsSet {
+			t.Fatal("AllowedOriginsIsSet should be true")
+		}
+	})
+
+	t.Run("PROXY_MODE is captured", func(t *testing.T) {
+		t.Setenv("ENV", "")
+		t.Setenv("ALLOWED_ORIGINS", "")
+		t.Setenv("PROXY_MODE", "simple")
+		section, err := HTTPModule{}.LoadAndValidate()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if section.ProxyMode != "simple" {
+			t.Fatalf("ProxyMode = %q, want %q", section.ProxyMode, "simple")
+		}
+	})
+}

--- a/backend/internal/config/services/logging_service.go
+++ b/backend/internal/config/services/logging_service.go
@@ -1,0 +1,38 @@
+package services
+
+import (
+	"github.com/alpyxn/aeterna/backend/internal/config/common"
+)
+
+type LoggingModule struct{}
+
+func (LoggingModule) Name() string { return "LoggingModule" }
+func (LoggingModule) Section() string {
+	return "logging"
+}
+
+func init() {
+	common.Register(LoggingModule{})
+}
+
+type LoggingSection struct {
+	Level      string
+	Format     string
+	File       string
+	MaxSize    int
+	MaxBackups int
+	MaxAge     int
+	Compress   bool
+}
+
+func (LoggingModule) LoadAndValidate() (LoggingSection, error) {
+	return LoggingSection{
+		Level:      common.GetenvTrim("LOG_LEVEL"),
+		Format:     common.GetenvTrim("LOG_FORMAT"),
+		File:       common.GetenvTrim("LOG_FILE"),
+		MaxSize:    common.GetInt("LOG_MAX_SIZE", common.DefaultLogMaxSize),
+		MaxBackups: common.GetInt("LOG_MAX_BACKUPS", common.DefaultLogMaxBackups),
+		MaxAge:     common.GetInt("LOG_MAX_AGE", common.DefaultLogMaxAge),
+		Compress:   common.GetBool("LOG_COMPRESS", common.DefaultLogCompress),
+	}, nil
+}

--- a/backend/internal/config/services/logging_service_test.go
+++ b/backend/internal/config/services/logging_service_test.go
@@ -1,0 +1,140 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/alpyxn/aeterna/backend/internal/config/common"
+)
+
+func TestLoggingModule_Metadata(t *testing.T) {
+	m := LoggingModule{}
+	if got := m.Name(); got != "LoggingModule" {
+		t.Fatalf("Name() = %q, want %q", got, "LoggingModule")
+	}
+	if got := m.Section(); got != "logging" {
+		t.Fatalf("Section() = %q, want %q", got, "logging")
+	}
+}
+
+func TestLoggingModule_LoadAndValidate(t *testing.T) {
+	t.Run("defaults when no env vars set", func(t *testing.T) {
+		t.Setenv("LOG_LEVEL", "")
+		t.Setenv("LOG_FORMAT", "")
+		t.Setenv("LOG_FILE", "")
+		t.Setenv("LOG_MAX_SIZE", "")
+		t.Setenv("LOG_MAX_BACKUPS", "")
+		t.Setenv("LOG_MAX_AGE", "")
+		t.Setenv("LOG_COMPRESS", "")
+		section, err := LoggingModule{}.LoadAndValidate()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if section.Level != "" {
+			t.Fatalf("Level = %q, want empty", section.Level)
+		}
+		if section.Format != "" {
+			t.Fatalf("Format = %q, want empty", section.Format)
+		}
+		if section.File != "" {
+			t.Fatalf("File = %q, want empty", section.File)
+		}
+		if section.MaxSize != common.DefaultLogMaxSize {
+			t.Fatalf("MaxSize = %d, want %d", section.MaxSize, common.DefaultLogMaxSize)
+		}
+		if section.MaxBackups != common.DefaultLogMaxBackups {
+			t.Fatalf("MaxBackups = %d, want %d", section.MaxBackups, common.DefaultLogMaxBackups)
+		}
+		if section.MaxAge != common.DefaultLogMaxAge {
+			t.Fatalf("MaxAge = %d, want %d", section.MaxAge, common.DefaultLogMaxAge)
+		}
+		if section.Compress != common.DefaultLogCompress {
+			t.Fatalf("Compress = %v, want %v", section.Compress, common.DefaultLogCompress)
+		}
+	})
+
+	t.Run("custom log level and format", func(t *testing.T) {
+		t.Setenv("LOG_LEVEL", "debug")
+		t.Setenv("LOG_FORMAT", "json")
+		section, err := LoggingModule{}.LoadAndValidate()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if section.Level != "debug" {
+			t.Fatalf("Level = %q, want %q", section.Level, "debug")
+		}
+		if section.Format != "json" {
+			t.Fatalf("Format = %q, want %q", section.Format, "json")
+		}
+	})
+
+	t.Run("custom log file path", func(t *testing.T) {
+		t.Setenv("LOG_FILE", "/var/log/aeterna.log")
+		section, err := LoggingModule{}.LoadAndValidate()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if section.File != "/var/log/aeterna.log" {
+			t.Fatalf("File = %q, want %q", section.File, "/var/log/aeterna.log")
+		}
+	})
+
+	t.Run("custom rotation settings", func(t *testing.T) {
+		t.Setenv("LOG_MAX_SIZE", "100")
+		t.Setenv("LOG_MAX_BACKUPS", "10")
+		t.Setenv("LOG_MAX_AGE", "30")
+		section, err := LoggingModule{}.LoadAndValidate()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if section.MaxSize != 100 {
+			t.Fatalf("MaxSize = %d, want 100", section.MaxSize)
+		}
+		if section.MaxBackups != 10 {
+			t.Fatalf("MaxBackups = %d, want 10", section.MaxBackups)
+		}
+		if section.MaxAge != 30 {
+			t.Fatalf("MaxAge = %d, want 30", section.MaxAge)
+		}
+	})
+
+	t.Run("invalid int values fall back to defaults", func(t *testing.T) {
+		t.Setenv("LOG_MAX_SIZE", "not-a-number")
+		t.Setenv("LOG_MAX_BACKUPS", "bad")
+		t.Setenv("LOG_MAX_AGE", "abc")
+		section, err := LoggingModule{}.LoadAndValidate()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if section.MaxSize != common.DefaultLogMaxSize {
+			t.Fatalf("MaxSize = %d, want default %d", section.MaxSize, common.DefaultLogMaxSize)
+		}
+		if section.MaxBackups != common.DefaultLogMaxBackups {
+			t.Fatalf("MaxBackups = %d, want default %d", section.MaxBackups, common.DefaultLogMaxBackups)
+		}
+		if section.MaxAge != common.DefaultLogMaxAge {
+			t.Fatalf("MaxAge = %d, want default %d", section.MaxAge, common.DefaultLogMaxAge)
+		}
+	})
+
+	t.Run("LOG_COMPRESS false disables compression", func(t *testing.T) {
+		t.Setenv("LOG_COMPRESS", "false")
+		section, err := LoggingModule{}.LoadAndValidate()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if section.Compress {
+			t.Fatal("Compress should be false")
+		}
+	})
+
+	t.Run("LOG_COMPRESS true enables compression", func(t *testing.T) {
+		t.Setenv("LOG_COMPRESS", "true")
+		section, err := LoggingModule{}.LoadAndValidate()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !section.Compress {
+			t.Fatal("Compress should be true")
+		}
+	})
+}

--- a/backend/internal/config/services/webhook_service.go
+++ b/backend/internal/config/services/webhook_service.go
@@ -1,0 +1,26 @@
+package services
+
+import (
+	"github.com/alpyxn/aeterna/backend/internal/config/common"
+)
+
+type WebhookModule struct{}
+
+func (WebhookModule) Name() string { return "WebhookModule" }
+func (WebhookModule) Section() string {
+	return "webhook"
+}
+
+func init() {
+	common.Register(WebhookModule{})
+}
+
+type WebhookSection struct {
+	AllowlistHosts string
+}
+
+func (WebhookModule) LoadAndValidate() (WebhookSection, error) {
+	return WebhookSection{
+		AllowlistHosts: common.GetenvTrim("WEBHOOK_ALLOWLIST_HOSTS"),
+	}, nil
+}

--- a/backend/internal/config/services/webhook_service_test.go
+++ b/backend/internal/config/services/webhook_service_test.go
@@ -1,0 +1,50 @@
+package services
+
+import (
+	"testing"
+)
+
+func TestWebhookModule_Metadata(t *testing.T) {
+	m := WebhookModule{}
+	if got := m.Name(); got != "WebhookModule" {
+		t.Fatalf("Name() = %q, want %q", got, "WebhookModule")
+	}
+	if got := m.Section(); got != "webhook" {
+		t.Fatalf("Section() = %q, want %q", got, "webhook")
+	}
+}
+
+func TestWebhookModule_LoadAndValidate(t *testing.T) {
+	t.Run("unset WEBHOOK_ALLOWLIST_HOSTS returns empty", func(t *testing.T) {
+		t.Setenv("WEBHOOK_ALLOWLIST_HOSTS", "")
+		section, err := WebhookModule{}.LoadAndValidate()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if section.AllowlistHosts != "" {
+			t.Fatalf("AllowlistHosts = %q, want empty", section.AllowlistHosts)
+		}
+	})
+
+	t.Run("custom allowlist hosts", func(t *testing.T) {
+		t.Setenv("WEBHOOK_ALLOWLIST_HOSTS", "hooks.example.com,api.example.com")
+		section, err := WebhookModule{}.LoadAndValidate()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if section.AllowlistHosts != "hooks.example.com,api.example.com" {
+			t.Fatalf("AllowlistHosts = %q, want %q", section.AllowlistHosts, "hooks.example.com,api.example.com")
+		}
+	})
+
+	t.Run("whitespace is trimmed", func(t *testing.T) {
+		t.Setenv("WEBHOOK_ALLOWLIST_HOSTS", "  hooks.example.com  ")
+		section, err := WebhookModule{}.LoadAndValidate()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if section.AllowlistHosts != "hooks.example.com" {
+			t.Fatalf("AllowlistHosts = %q, want trimmed value", section.AllowlistHosts)
+		}
+	})
+}

--- a/backend/internal/config/services/worker_service.go
+++ b/backend/internal/config/services/worker_service.go
@@ -1,0 +1,26 @@
+package services
+
+import (
+	"github.com/alpyxn/aeterna/backend/internal/config/common"
+)
+
+type WorkerModule struct{}
+
+func (WorkerModule) Name() string { return "WorkerModule" }
+func (WorkerModule) Section() string {
+	return "worker"
+}
+
+func init() {
+	common.Register(WorkerModule{})
+}
+
+type WorkerSection struct {
+	BaseURL string
+}
+
+func (WorkerModule) LoadAndValidate() (WorkerSection, error) {
+	return WorkerSection{
+		BaseURL: common.WithDefault(common.GetenvTrim("BASE_URL"), common.DefaultWorkerBaseURL),
+	}, nil
+}

--- a/backend/internal/config/services/worker_service_test.go
+++ b/backend/internal/config/services/worker_service_test.go
@@ -1,0 +1,52 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/alpyxn/aeterna/backend/internal/config/common"
+)
+
+func TestWorkerModule_Metadata(t *testing.T) {
+	m := WorkerModule{}
+	if got := m.Name(); got != "WorkerModule" {
+		t.Fatalf("Name() = %q, want %q", got, "WorkerModule")
+	}
+	if got := m.Section(); got != "worker" {
+		t.Fatalf("Section() = %q, want %q", got, "worker")
+	}
+}
+
+func TestWorkerModule_LoadAndValidate(t *testing.T) {
+	t.Run("unset BASE_URL uses default", func(t *testing.T) {
+		t.Setenv("BASE_URL", "")
+		section, err := WorkerModule{}.LoadAndValidate()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if section.BaseURL != common.DefaultWorkerBaseURL {
+			t.Fatalf("BaseURL = %q, want default %q", section.BaseURL, common.DefaultWorkerBaseURL)
+		}
+	})
+
+	t.Run("custom BASE_URL", func(t *testing.T) {
+		t.Setenv("BASE_URL", "https://app.example.com")
+		section, err := WorkerModule{}.LoadAndValidate()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if section.BaseURL != "https://app.example.com" {
+			t.Fatalf("BaseURL = %q, want %q", section.BaseURL, "https://app.example.com")
+		}
+	})
+
+	t.Run("BASE_URL whitespace is trimmed", func(t *testing.T) {
+		t.Setenv("BASE_URL", "  https://app.example.com  ")
+		section, err := WorkerModule{}.LoadAndValidate()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if section.BaseURL != "https://app.example.com" {
+			t.Fatalf("BaseURL = %q, want trimmed value", section.BaseURL)
+		}
+	})
+}

--- a/backend/internal/config/types.go
+++ b/backend/internal/config/types.go
@@ -1,0 +1,35 @@
+package config
+
+import (
+	"github.com/alpyxn/aeterna/backend/internal/config/common"
+	"github.com/alpyxn/aeterna/backend/internal/config/services"
+)
+
+type Config struct {
+	App      services.AppSection      `config:"app"`
+	Database services.DatabaseSection `config:"database"`
+	HTTP     services.HTTPSection     `config:"http"`
+	Auth     services.AuthSection     `config:"auth"`
+	Logging  services.LoggingSection  `config:"logging"`
+	Worker   services.WorkerSection   `config:"worker"`
+	Webhook  services.WebhookSection  `config:"webhook"`
+}
+
+type AppConfig = services.AppSection
+type DatabaseConfig = services.DatabaseSection
+type HTTPConfig = services.HTTPSection
+type AuthConfig = services.AuthSection
+type LoggingConfig = services.LoggingSection
+type WorkerConfig = services.WorkerSection
+type WebhookConfig = services.WebhookSection
+
+func (c Config) IsProduction() bool {
+	return c.App.Env == "production"
+}
+
+func (c Config) AllowedOriginsOrDefault() string {
+	if c.HTTP.AllowedOrigins == "" {
+		return common.DefaultAllowedOrigins
+	}
+	return c.HTTP.AllowedOrigins
+}

--- a/backend/internal/database/database.go
+++ b/backend/internal/database/database.go
@@ -5,20 +5,18 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/alpyxn/aeterna/backend/internal/config"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
 
 var DB *gorm.DB
 
-func Connect() {
-	dbPath := os.Getenv("DATABASE_PATH")
-	if dbPath == "" {
-		dbPath = "./data/aeterna.db"
-	}
+func Connect(cfg config.Config) {
+	dbPath := cfg.Database.Path
 
 	// Warn if PostgreSQL environment variables are set (Aeterna uses SQLite only)
-	if os.Getenv("DB_HOST") != "" || os.Getenv("POSTGRES_HOST") != "" || os.Getenv("DATABASE_URL") != "" {
+	if cfg.Database.DBHost != "" || cfg.Database.PostgresHost != "" || cfg.Database.DatabaseURL != "" {
 		log.Println("WARNING: PostgreSQL environment variables detected, but Aeterna uses SQLite only.")
 		log.Println("Ignoring PostgreSQL configuration and using SQLite at:", dbPath)
 	}

--- a/backend/internal/database/migrate.go
+++ b/backend/internal/database/migrate.go
@@ -7,23 +7,22 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/alpyxn/aeterna/backend/internal/config"
 	"github.com/alpyxn/aeterna/backend/internal/models"
 	"github.com/google/uuid"
 	"golang.org/x/crypto/bcrypt"
 	"gorm.io/gorm"
 )
 
-func uploadsBaseDir() string {
-	dbPath := os.Getenv("DATABASE_PATH")
-	if dbPath != "" {
-		return filepath.Join(filepath.Dir(dbPath), "uploads")
-	}
-	return filepath.Join(".", "data", "uploads")
+func uploadsBaseDir(dbPath string) string {
+	return filepath.Join(filepath.Dir(dbPath), "uploads")
 }
 
 // MigrateLegacyToMultitenant assigns a single legacy user to existing rows when upgrading
 // from single-tenant installs. Safe to call on every startup (idempotent).
-func MigrateLegacyToMultitenant(db *gorm.DB) error {
+func MigrateLegacyToMultitenant(db *gorm.DB, cfg config.Config) error {
+	dbPath := cfg.Database.Path
+	masterPassword := cfg.Auth.MasterPassword
 	var userCount int64
 	if err := db.Model(&models.User{}).Count(&userCount).Error; err != nil {
 		return err
@@ -52,7 +51,7 @@ func MigrateLegacyToMultitenant(db *gorm.DB) error {
 
 	pwdHash := settings.MasterPasswordHash
 	if pwdHash == "" {
-		if env := os.Getenv("MASTER_PASSWORD"); env != "" {
+		if env := masterPassword; env != "" {
 			h, err := bcrypt.GenerateFromPassword([]byte(env), bcrypt.DefaultCost)
 			if err != nil {
 				return err
@@ -90,7 +89,7 @@ func MigrateLegacyToMultitenant(db *gorm.DB) error {
 		return err
 	}
 
-	if err := migrateLegacyUploadPaths(db, uid); err != nil {
+	if err := migrateLegacyUploadPaths(db, uid, dbPath); err != nil {
 		log.Println("Warning: legacy upload path migration:", err)
 	}
 
@@ -114,8 +113,8 @@ func backfillOrphanUserIDs(db *gorm.DB) error {
 	return db.Model(&models.Attachment{}).Where(q).Update("user_id", uid).Error
 }
 
-func migrateLegacyUploadPaths(db *gorm.DB, legacyUserID string) error {
-	base := uploadsBaseDir()
+func migrateLegacyUploadPaths(db *gorm.DB, legacyUserID, dbPath string) error {
+	base := uploadsBaseDir(dbPath)
 	entries, err := os.ReadDir(base)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/backend/internal/handlers/auth.go
+++ b/backend/internal/handlers/auth.go
@@ -1,9 +1,9 @@
 package handlers
 
 import (
-	"os"
 	"time"
 
+	"github.com/alpyxn/aeterna/backend/internal/config"
 	"github.com/alpyxn/aeterna/backend/internal/middleware"
 	"github.com/alpyxn/aeterna/backend/internal/ports"
 	"github.com/alpyxn/aeterna/backend/internal/services"
@@ -24,10 +24,11 @@ type loginRequest struct {
 // AuthHandlers groups all authentication-related route handlers.
 type AuthHandlers struct {
 	auth ports.AuthServicePort
+	cfg  config.Config
 }
 
-func NewAuthHandlers(auth ports.AuthServicePort) *AuthHandlers {
-	return &AuthHandlers{auth: auth}
+func NewAuthHandlers(auth ports.AuthServicePort, cfg config.Config) *AuthHandlers {
+	return &AuthHandlers{auth: auth, cfg: cfg}
 }
 
 func (h *AuthHandlers) SetupStatus(c *fiber.Ctx) error {
@@ -183,7 +184,7 @@ func (h *AuthHandlers) SessionStatus(c *fiber.Ctx) error {
 }
 
 func (h *AuthHandlers) Logout(c *fiber.Ctx) error {
-	clearSessionCookie(c)
+	h.clearSessionCookie(c)
 	return c.JSON(fiber.Map{"success": true})
 }
 
@@ -192,8 +193,7 @@ func (h *AuthHandlers) issueSessionCookie(c *fiber.Ctx, userID string) error {
 	if err != nil {
 		return err
 	}
-	isHTTPS := c.Protocol() == "https" || c.Get("X-Forwarded-Proto") == "https"
-	secure := os.Getenv("ENV") == "production" && isHTTPS
+	secure := middleware.ShouldUseSecureCookie(c, h.cfg.Auth.CookieSecureMode)
 	c.Cookie(&fiber.Cookie{
 		Name:     "aeterna_session",
 		Value:    token,
@@ -206,9 +206,8 @@ func (h *AuthHandlers) issueSessionCookie(c *fiber.Ctx, userID string) error {
 	return nil
 }
 
-func clearSessionCookie(c *fiber.Ctx) {
-	isHTTPS := c.Protocol() == "https" || c.Get("X-Forwarded-Proto") == "https"
-	secure := os.Getenv("ENV") == "production" && isHTTPS
+func (h *AuthHandlers) clearSessionCookie(c *fiber.Ctx) {
+	secure := middleware.ShouldUseSecureCookie(c, h.cfg.Auth.CookieSecureMode)
 	c.Cookie(&fiber.Cookie{
 		Name:     "aeterna_session",
 		Value:    "",

--- a/backend/internal/handlers/response.go
+++ b/backend/internal/handlers/response.go
@@ -2,11 +2,17 @@ package handlers
 
 import (
 	"errors"
-	"os"
 
+	"github.com/alpyxn/aeterna/backend/internal/config"
 	"github.com/alpyxn/aeterna/backend/internal/services"
 	"github.com/gofiber/fiber/v2"
 )
+
+var isProduction bool
+
+// SetIsProduction configures whether the handler package runs in production mode.
+// Call once from main before registering routes.
+func SetIsProduction(cfg config.Config) { isProduction = cfg.IsProduction() }
 
 func currentUserID(c *fiber.Ctx) (string, error) {
 	uid, ok := c.Locals("user_id").(string)
@@ -17,6 +23,7 @@ func currentUserID(c *fiber.Ctx) (string, error) {
 }
 
 func writeError(c *fiber.Ctx, err error) error {
+	isProd := isProduction
 	var apiErr *services.APIError
 	if errors.As(err, &apiErr) {
 		code := apiErr.Code
@@ -27,7 +34,7 @@ func writeError(c *fiber.Ctx, err error) error {
 			"error": apiErr.Message,
 			"code":  code,
 		}
-		if os.Getenv("ENV") != "production" && apiErr.Err != nil {
+		if !isProd && apiErr.Err != nil {
 			payload["detail"] = apiErr.Err.Error()
 		}
 		return c.Status(apiErr.Status).JSON(payload)
@@ -36,7 +43,7 @@ func writeError(c *fiber.Ctx, err error) error {
 		"error": "Internal server error",
 		"code":  "internal_error",
 	}
-	if os.Getenv("ENV") != "production" && err != nil {
+	if !isProd && err != nil {
 		payload["detail"] = err.Error()
 	}
 	return c.Status(500).JSON(payload)

--- a/backend/internal/logging/logger.go
+++ b/backend/internal/logging/logger.go
@@ -3,25 +3,24 @@ package logging
 import (
 	"log/slog"
 	"os"
-	"strconv"
 	"strings"
 
+	"github.com/alpyxn/aeterna/backend/internal/config"
 	"gopkg.in/natefinch/lumberjack.v2"
 )
 
-func Init() *slog.Logger {
-	level := parseLevel(os.Getenv("LOG_LEVEL"))
-	format := strings.ToLower(os.Getenv("LOG_FORMAT"))
+func Init(cfg config.Config) *slog.Logger {
+	level := parseLevel(cfg.Logging.Level)
+	format := strings.ToLower(cfg.Logging.Format)
 
 	var output *lumberjack.Logger
-	logFile := os.Getenv("LOG_FILE")
-	if logFile != "" {
+	if cfg.Logging.File != "" {
 		output = &lumberjack.Logger{
-			Filename:   logFile,
-			MaxSize:    getEnvInt("LOG_MAX_SIZE", 50),
-			MaxBackups: getEnvInt("LOG_MAX_BACKUPS", 5),
-			MaxAge:     getEnvInt("LOG_MAX_AGE", 14),
-			Compress:   getEnvBool("LOG_COMPRESS", true),
+			Filename:   cfg.Logging.File,
+			MaxSize:    cfg.Logging.MaxSize,
+			MaxBackups: cfg.Logging.MaxBackups,
+			MaxAge:     cfg.Logging.MaxAge,
+			Compress:   cfg.Logging.Compress,
 		}
 	}
 
@@ -60,28 +59,4 @@ func parseLevel(value string) slog.Level {
 	default:
 		return slog.LevelInfo
 	}
-}
-
-func getEnvInt(key string, fallback int) int {
-	val := os.Getenv(key)
-	if val == "" {
-		return fallback
-	}
-	parsed, err := strconv.Atoi(val)
-	if err != nil {
-		return fallback
-	}
-	return parsed
-}
-
-func getEnvBool(key string, fallback bool) bool {
-	val := os.Getenv(key)
-	if val == "" {
-		return fallback
-	}
-	parsed, err := strconv.ParseBool(val)
-	if err != nil {
-		return fallback
-	}
-	return parsed
 }

--- a/backend/internal/middleware/auth.go
+++ b/backend/internal/middleware/auth.go
@@ -3,39 +3,43 @@ package middleware
 import (
 	"log/slog"
 	"net/url"
-	"os"
 	"strings"
+	"time"
 
-	"github.com/alpyxn/aeterna/backend/internal/services"
+	"github.com/alpyxn/aeterna/backend/internal/config"
+	"github.com/alpyxn/aeterna/backend/internal/ports"
 	"github.com/gofiber/fiber/v2"
 )
 
-var authService = services.AuthService{}
-
-func MasterAuth(c *fiber.Ctx) error {
-	if token := c.Cookies("aeterna_session"); token != "" {
-		userID, err := authService.VerifySessionToken(token)
-		if err == nil {
-			if err := enforceOriginAllowlist(c); err != nil {
-				return err
+// MasterAuth returns a middleware that validates the session cookie and enforces the origin allowlist.
+func MasterAuth(auth ports.AuthServicePort, cfg config.Config) fiber.Handler {
+	allowedOrigins := cfg.AllowedOriginsOrDefault()
+	isProd := cfg.IsProduction()
+	cookieSecureMode := cfg.Auth.CookieSecureMode
+	return func(c *fiber.Ctx) error {
+		if token := c.Cookies("aeterna_session"); token != "" {
+			userID, err := auth.VerifySessionToken(token)
+			if err == nil {
+				if err := enforceOriginAllowlist(c, allowedOrigins, isProd); err != nil {
+					return err
+				}
+				c.Locals("user_id", userID)
+				return c.Next()
 			}
-			c.Locals("user_id", userID)
-			return c.Next()
+			clearSessionCookieWith(c, cookieSecureMode)
 		}
-		c.ClearCookie("aeterna_session")
-	}
 
-	return c.Status(401).JSON(fiber.Map{
-		"error": "Unauthorized access. Session required.",
-		"code":  "unauthorized",
-	})
+		return c.Status(401).JSON(fiber.Map{
+			"error": "Unauthorized access. Session required.",
+			"code":  "unauthorized",
+		})
+	}
 }
 
-func enforceOriginAllowlist(c *fiber.Ctx) error {
+func enforceOriginAllowlist(c *fiber.Ctx, allowedOrigins string, isProd bool) error {
 	origin := strings.TrimSpace(c.Get("Origin"))
-	allowedOrigins := strings.TrimSpace(os.Getenv("ALLOWED_ORIGINS"))
 
-	if os.Getenv("ENV") != "production" {
+	if !isProd {
 		slog.Info("Origin check", "origin", origin, "allowed", allowedOrigins, "referer", c.Get("Referer"))
 	}
 
@@ -54,8 +58,7 @@ func enforceOriginAllowlist(c *fiber.Ctx) error {
 	}
 
 	if origin == "" {
-		env := os.Getenv("ENV")
-		if env != "production" {
+		if !isProd {
 			return nil
 		}
 		return c.Status(403).JSON(fiber.Map{
@@ -90,4 +93,41 @@ func enforceOriginAllowlist(c *fiber.Ctx) error {
 		"error": "Origin not allowed",
 		"code":  "origin_not_allowed",
 	})
+}
+
+func clearSessionCookieWith(c *fiber.Ctx, cookieSecureMode string) {
+	secure := ShouldUseSecureCookie(c, cookieSecureMode)
+	c.Cookie(&fiber.Cookie{
+		Name:     "aeterna_session",
+		Value:    "",
+		Expires:  time.Unix(0, 0),
+		MaxAge:   -1,
+		Path:     "/",
+		HTTPOnly: true,
+		Secure:   secure,
+		SameSite: fiber.CookieSameSiteStrictMode,
+	})
+}
+
+// ShouldUseSecureCookie returns true when the session cookie should be flagged Secure.
+func ShouldUseSecureCookie(c *fiber.Ctx, cookieSecureMode string) bool {
+	switch cookieSecureMode {
+	case "always":
+		return true
+	case "never":
+		return false
+	}
+	return requestIsHTTPS(c)
+}
+
+func requestIsHTTPS(c *fiber.Ctx) bool {
+	if c.Protocol() == "https" {
+		return true
+	}
+	forwardedProto := strings.ToLower(strings.TrimSpace(c.Get("X-Forwarded-Proto")))
+	if forwardedProto == "" {
+		return false
+	}
+	first := strings.TrimSpace(strings.Split(forwardedProto, ",")[0])
+	return first == "https"
 }

--- a/backend/internal/middleware/security.go
+++ b/backend/internal/middleware/security.go
@@ -1,43 +1,32 @@
 package middleware
 
 import (
-	"os"
 	"strings"
 
+	"github.com/alpyxn/aeterna/backend/internal/config"
 	"github.com/gofiber/fiber/v2"
 )
 
-// SecurityHeaders adds security-related HTTP headers to all responses
-func SecurityHeaders(c *fiber.Ctx) error {
-	// Prevent MIME type sniffing
-	c.Set("X-Content-Type-Options", "nosniff")
+// SecurityHeaders returns a middleware that adds security-related HTTP headers.
+func SecurityHeaders(cfg config.Config) fiber.Handler {
+	isProd := cfg.IsProduction()
+	return func(c *fiber.Ctx) error {
+		c.Set("X-Content-Type-Options", "nosniff")
+		c.Set("X-Frame-Options", "DENY")
+		c.Set("Referrer-Policy", "strict-origin-when-cross-origin")
+		c.Set("Permissions-Policy", "geolocation=(), camera=(), microphone=(), payment=()")
+		c.Set("Content-Security-Policy", "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'")
 
-	// Prevent clickjacking
-	c.Set("X-Frame-Options", "DENY")
+		if isProd {
+			c.Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+		}
 
-	// XSS Protection (legacy but still useful for older browsers)
-	c.Set("X-XSS-Protection", "1; mode=block")
+		if strings.HasPrefix(c.Path(), "/api") {
+			c.Set("Cache-Control", "no-store, no-cache, must-revalidate, private")
+			c.Set("Pragma", "no-cache")
+			c.Set("Expires", "0")
+		}
 
-	// Control referrer information
-	c.Set("Referrer-Policy", "strict-origin-when-cross-origin")
-
-	// Permissions Policy (formerly Feature-Policy)
-	c.Set("Permissions-Policy", "geolocation=(), camera=(), microphone=(), payment=()")
-
-	// Content Security Policy - prevents XSS and injection attacks
-	c.Set("Content-Security-Policy", "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'")
-
-	// Strict Transport Security (only in production with HTTPS)
-	if os.Getenv("ENV") == "production" {
-		c.Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+		return c.Next()
 	}
-
-	// Prevent caching of sensitive API responses
-	if strings.HasPrefix(c.Path(), "/api") {
-		c.Set("Cache-Control", "no-store, no-cache, must-revalidate, private")
-		c.Set("Pragma", "no-cache")
-		c.Set("Expires", "0")
-	}
-
-	return c.Next()
 }

--- a/backend/internal/services/auth_service.go
+++ b/backend/internal/services/auth_service.go
@@ -7,18 +7,23 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
-	"strconv"
 	"strings"
 	"time"
 
+	"github.com/alpyxn/aeterna/backend/internal/config"
 	"github.com/alpyxn/aeterna/backend/internal/database"
 	"github.com/alpyxn/aeterna/backend/internal/models"
 	"golang.org/x/crypto/bcrypt"
 	"gorm.io/gorm"
 )
 
-type AuthService struct{}
+type AuthService struct {
+	cfg config.Config
+}
+
+func NewAuthService(cfg config.Config) AuthService {
+	return AuthService{cfg: cfg}
+}
 
 type sessionClaims struct {
 	Exp    int64  `json:"exp"`
@@ -48,7 +53,7 @@ func (s AuthService) IssueSessionToken(userID string) (string, time.Time, error)
 	if err != nil {
 		return "", time.Time{}, err
 	}
-	ttl := sessionTTL()
+	ttl := s.sessionTTL()
 	now := time.Now().UTC()
 	exp := now.Add(ttl)
 
@@ -108,16 +113,8 @@ func (s AuthService) VerifySessionToken(token string) (userID string, err error)
 	return claims.UserID, nil
 }
 
-func sessionTTL() time.Duration {
-	raw := os.Getenv("AUTH_SESSION_TTL_HOURS")
-	if raw == "" {
-		return 12 * time.Hour
-	}
-	hours, err := strconv.Atoi(raw)
-	if err != nil || hours <= 0 {
-		return 12 * time.Hour
-	}
-	return time.Duration(hours) * time.Hour
+func (s AuthService) sessionTTL() time.Duration {
+	return time.Duration(s.cfg.Auth.SessionTTLHours) * time.Hour
 }
 
 // IsConfigured returns true when at least one user account exists.
@@ -208,7 +205,7 @@ var applicationSettingsService = ApplicationSettingsService{}
 
 // AdditionalRegistrationOpen reports whether self-service registration is allowed when an account already exists (env or DB flag).
 func (s AuthService) AdditionalRegistrationOpen() (bool, error) {
-	if os.Getenv("ALLOW_REGISTRATION") == "true" {
+	if s.cfg.Auth.AllowRegistration {
 		return true, nil
 	}
 	app, err := applicationSettingsService.Get()
@@ -314,7 +311,7 @@ func (s AuthService) Login(email, password string) (models.User, error) {
 		return models.User{}, BadRequest("Email and password are required", nil)
 	}
 
-	if envPassword := os.Getenv("MASTER_PASSWORD"); envPassword != "" {
+	if envPassword := s.cfg.Auth.MasterPassword; envPassword != "" {
 		var n int64
 		database.DB.Model(&models.User{}).Count(&n)
 		if n == 1 {

--- a/backend/internal/services/auth_service_test.go
+++ b/backend/internal/services/auth_service_test.go
@@ -1,49 +1,29 @@
 package services
 
 import (
-	"os"
 	"testing"
 	"time"
+
+	"github.com/alpyxn/aeterna/backend/internal/config"
 )
 
-func TestSessionTTLDefault(t *testing.T) {
-	old := os.Getenv("AUTH_SESSION_TTL_HOURS")
-	defer func() {
-		if old == "" {
-			_ = os.Unsetenv("AUTH_SESSION_TTL_HOURS")
-			return
-		}
-		_ = os.Setenv("AUTH_SESSION_TTL_HOURS", old)
-	}()
-
-	_ = os.Unsetenv("AUTH_SESSION_TTL_HOURS")
-	if got := sessionTTL(); got != 12*time.Hour {
-		t.Fatalf("expected default 12h, got %v", got)
+func TestSessionTTL(t *testing.T) {
+	tests := []struct {
+		name  string
+		hours int
+		want  time.Duration
+	}{
+		{"twelve hours", 12, 12 * time.Hour},
+		{"six hours", 6, 6 * time.Hour},
+		{"one hour", 1, time.Hour},
+		{"large value", 720, 720 * time.Hour},
 	}
-}
-
-func TestSessionTTLFromEnv(t *testing.T) {
-	old := os.Getenv("AUTH_SESSION_TTL_HOURS")
-	defer func() {
-		if old == "" {
-			_ = os.Unsetenv("AUTH_SESSION_TTL_HOURS")
-			return
-		}
-		_ = os.Setenv("AUTH_SESSION_TTL_HOURS", old)
-	}()
-
-	_ = os.Setenv("AUTH_SESSION_TTL_HOURS", "6")
-	if got := sessionTTL(); got != 6*time.Hour {
-		t.Fatalf("expected 6h, got %v", got)
-	}
-
-	_ = os.Setenv("AUTH_SESSION_TTL_HOURS", "not-a-number")
-	if got := sessionTTL(); got != 12*time.Hour {
-		t.Fatalf("expected fallback 12h for invalid value, got %v", got)
-	}
-
-	_ = os.Setenv("AUTH_SESSION_TTL_HOURS", "0")
-	if got := sessionTTL(); got != 12*time.Hour {
-		t.Fatalf("expected fallback 12h for non-positive value, got %v", got)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := NewAuthService(config.Config{Auth: config.AuthConfig{SessionTTLHours: tc.hours}})
+			if got := svc.sessionTTL(); got != tc.want {
+				t.Fatalf("expected %v, got %v", tc.want, got)
+			}
+		})
 	}
 }

--- a/backend/internal/services/farewell_service_test.go
+++ b/backend/internal/services/farewell_service_test.go
@@ -1,0 +1,73 @@
+package services
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/alpyxn/aeterna/backend/internal/models"
+)
+
+func initTestKeyManager(t *testing.T) {
+	t.Helper()
+	key, err := GenerateKey()
+	if err != nil {
+		t.Fatalf("failed to generate test key: %v", err)
+	}
+
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "enc.key")
+	if err := os.WriteFile(keyPath, []byte(key), 0600); err != nil {
+		t.Fatalf("failed to write test key: %v", err)
+	}
+	if err := os.Chmod(keyPath, 0600); err != nil {
+		t.Fatalf("failed to chmod test key: %v", err)
+	}
+
+	InitKeyManager(keyPath)
+}
+
+func TestFarewellCreate_PersistsZeroDelay(t *testing.T) {
+	db := setupTestDB(t)
+	initTestKeyManager(t)
+
+	msg := models.Message{
+		ID:              "m-delay-zero",
+		UserID:          "u-delay-zero",
+		Content:         "encrypted",
+		KeyFragment:     "v1",
+		ManagementToken: "tok",
+		RecipientEmail:  "owner@example.com",
+		TriggerDuration: 60,
+		LastSeen:        time.Now(),
+		Status:          models.StatusActive,
+	}
+	if err := db.Create(&msg).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	letter, err := (FarewellService{}).Create(
+		msg.UserID,
+		msg.ID,
+		"recipient@example.com",
+		"Subject",
+		"Content",
+		0,
+	)
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	if letter.DelayMinutes != 0 {
+		t.Fatalf("expected returned delay 0, got %d", letter.DelayMinutes)
+	}
+
+	var stored models.FarewellLetter
+	if err := db.First(&stored, "id = ?", letter.ID).Error; err != nil {
+		t.Fatalf("failed to load stored farewell letter: %v", err)
+	}
+	if stored.DelayMinutes != 0 {
+		t.Fatalf("expected stored delay 0, got %d", stored.DelayMinutes)
+	}
+}

--- a/backend/internal/services/file_service.go
+++ b/backend/internal/services/file_service.go
@@ -7,30 +7,36 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/alpyxn/aeterna/backend/internal/config"
 	"github.com/alpyxn/aeterna/backend/internal/database"
 	"github.com/alpyxn/aeterna/backend/internal/models"
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 )
 
-type FileService struct{}
+type FileService struct {
+	cfg config.Config
+}
+
+func NewFileService(cfg config.Config) FileService {
+	return FileService{cfg: cfg}
+}
 
 var fileCryptoService = CryptoService{}
 var fileValidationService = ValidationService{}
 
-// GetUploadsDir returns the base directory for file uploads
-func GetUploadsDir() string {
-	dbPath := os.Getenv("DATABASE_PATH")
-	if dbPath != "" {
-		return filepath.Join(filepath.Dir(dbPath), "uploads")
-	}
-	return filepath.Join(".", "data", "uploads")
+func (s FileService) uploadsDir() string {
+	return filepath.Join(filepath.Dir(s.cfg.Database.Path), "uploads")
 }
 
-// EnsureUploadsDir creates the uploads directory if it does not exist
-func EnsureUploadsDir() error {
-	dir := GetUploadsDir()
-	return os.MkdirAll(dir, 0700)
+// GetUploadsDir returns the base directory for file uploads given a database path.
+func GetUploadsDir(dbPath string) string {
+	return filepath.Join(filepath.Dir(dbPath), "uploads")
+}
+
+// EnsureUploadsDir creates the uploads directory if it does not exist.
+func EnsureUploadsDir(dbPath string) error {
+	return os.MkdirAll(GetUploadsDir(dbPath), 0700)
 }
 
 // Upload validates, encrypts, and stores a file on disk, then creates a DB record
@@ -70,7 +76,7 @@ func (s FileService) Upload(userID, messageID, filename, mimeType string, data [
 		return models.Attachment{}, Internal("Failed to encrypt file", err)
 	}
 
-	userDir := filepath.Join(GetUploadsDir(), userID)
+	userDir := filepath.Join(s.uploadsDir(), userID)
 	msgDir := filepath.Join(userDir, messageID)
 	if err := os.MkdirAll(msgDir, 0700); err != nil {
 		return models.Attachment{}, Internal("Failed to create upload directory", err)
@@ -140,7 +146,7 @@ func (s FileService) DeleteByMessageID(userID, messageID string) error {
 		return Internal("Failed to delete attachment records", err)
 	}
 
-	msgDir := filepath.Join(GetUploadsDir(), userID, messageID)
+	msgDir := filepath.Join(s.uploadsDir(), userID, messageID)
 	os.Remove(msgDir)
 
 	slog.Info("All attachments deleted for message", "message_id", messageID)
@@ -224,7 +230,7 @@ func (s FileService) UploadFarewellAttachment(userID, letterID, filename, mimeTy
 		return models.FarewellAttachment{}, Internal("Failed to encrypt file", err)
 	}
 
-	letterDir := filepath.Join(GetUploadsDir(), userID, "farewell", letterID)
+	letterDir := filepath.Join(s.uploadsDir(), userID, "farewell", letterID)
 	if err := os.MkdirAll(letterDir, 0700); err != nil {
 		return models.FarewellAttachment{}, Internal("Failed to create upload directory", err)
 	}
@@ -311,7 +317,7 @@ func (s FileService) DeleteFarewellAttachmentsByLetterID(userID, letterID string
 		return Internal("Failed to delete farewell attachment records", err)
 	}
 
-	letterDir := filepath.Join(GetUploadsDir(), userID, "farewell", letterID)
+	letterDir := filepath.Join(s.uploadsDir(), userID, "farewell", letterID)
 	os.Remove(letterDir)
 
 	slog.Info("All farewell attachments deleted", "letter_id", letterID)

--- a/backend/internal/services/message_service_delete_test.go
+++ b/backend/internal/services/message_service_delete_test.go
@@ -1,0 +1,75 @@
+package services
+
+import (
+	"testing"
+	"time"
+
+	"github.com/alpyxn/aeterna/backend/internal/database"
+	"github.com/alpyxn/aeterna/backend/internal/models"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared&_foreign_keys=1"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(
+		&models.Message{},
+		&models.MessageReminder{},
+		&models.Attachment{},
+		&models.FarewellLetter{},
+		&models.FarewellAttachment{},
+	); err != nil {
+		t.Fatal(err)
+	}
+	prev := database.DB
+	database.DB = db
+	t.Cleanup(func() { database.DB = prev })
+	return db
+}
+
+func TestMessageDelete_NoFarewellNoAttachments(t *testing.T) {
+	db := setupTestDB(t)
+	if err := db.Create(&models.Message{
+		ID: "m1", UserID: "u1", Content: "x", KeyFragment: "v1",
+		ManagementToken: "tok", RecipientEmail: "a@a.com",
+		TriggerDuration: 60, LastSeen: time.Now(), Status: models.StatusActive,
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	if err := (MessageService{}).Delete("u1", "m1"); err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestMessageDelete_WithFarewellLetter(t *testing.T) {
+	db := setupTestDB(t)
+	if err := db.Create(&models.Message{
+		ID: "m1", UserID: "u1", Content: "x", KeyFragment: "v1",
+		ManagementToken: "tok", RecipientEmail: "a@a.com",
+		TriggerDuration: 60, LastSeen: time.Now(), Status: models.StatusActive,
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&models.FarewellLetter{
+		ID: "l1", UserID: "u1", MessageID: "m1",
+		RecipientEmail: "b@b.com", Subject: "bye", Content: "x",
+		DelayMinutes: 60, Status: models.FarewellStatusPending,
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	if err := (MessageService{}).Delete("u1", "m1"); err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+
+	var count int64
+	db.Unscoped().Model(&models.FarewellLetter{}).Where("message_id = ?", "m1").Count(&count)
+	if count != 0 {
+		t.Fatalf("expected 0 farewell letters after delete, got %d", count)
+	}
+}

--- a/backend/internal/services/settings_service.go
+++ b/backend/internal/services/settings_service.go
@@ -6,12 +6,19 @@ import (
 	"net/smtp"
 	"strings"
 
+	"github.com/alpyxn/aeterna/backend/internal/config"
 	"github.com/alpyxn/aeterna/backend/internal/database"
 	"github.com/alpyxn/aeterna/backend/internal/models"
 	"gorm.io/gorm"
 )
 
-type SettingsService struct{}
+type SettingsService struct {
+	cfg config.Config
+}
+
+func NewSettingsService(cfg config.Config) SettingsService {
+	return SettingsService{cfg: cfg}
+}
 
 func (s SettingsService) Get(userID string) (models.Settings, error) {
 	var settings models.Settings
@@ -58,7 +65,7 @@ func (s SettingsService) Save(userID string, req models.Settings) error {
 		return BadRequest("Webhook URL is required", nil)
 	}
 	if req.WebhookURL != "" {
-		validatedURL, err := validateWebhookURL(req.WebhookURL)
+		validatedURL, err := validateWebhookURL(req.WebhookURL, s.cfg.Webhook.AllowlistHosts)
 		if err != nil {
 			return err
 		}

--- a/backend/internal/services/user_admin_service.go
+++ b/backend/internal/services/user_admin_service.go
@@ -6,13 +6,20 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/alpyxn/aeterna/backend/internal/config"
 	"github.com/alpyxn/aeterna/backend/internal/database"
 	"github.com/alpyxn/aeterna/backend/internal/models"
 	"gorm.io/gorm"
 )
 
 // UserAdminService manages accounts for the primary administrator only.
-type UserAdminService struct{}
+type UserAdminService struct {
+	cfg config.Config
+}
+
+func NewUserAdminService(cfg config.Config) UserAdminService {
+	return UserAdminService{cfg: cfg}
+}
 
 // List returns all accounts when the actor is the primary (first) user.
 func (s UserAdminService) List(actorUserID string) ([]models.UserListItem, error) {
@@ -118,10 +125,6 @@ func (s UserAdminService) Delete(actorUserID, targetUserID string) error {
 		return err
 	}
 
-	removeUserUploadsDir(targetUserID)
+	_ = os.RemoveAll(filepath.Join(GetUploadsDir(s.cfg.Database.Path), targetUserID))
 	return nil
-}
-
-func removeUserUploadsDir(userID string) {
-	_ = os.RemoveAll(filepath.Join(GetUploadsDir(), userID))
 }

--- a/backend/internal/services/webhook_store.go
+++ b/backend/internal/services/webhook_store.go
@@ -4,16 +4,22 @@ import (
 	"errors"
 	"net"
 	"net/url"
-	"os"
 	"strconv"
 	"strings"
 
+	"github.com/alpyxn/aeterna/backend/internal/config"
 	"github.com/alpyxn/aeterna/backend/internal/database"
 	"github.com/alpyxn/aeterna/backend/internal/models"
 	"gorm.io/gorm"
 )
 
-type WebhookStore struct{}
+type WebhookStore struct {
+	cfg config.Config
+}
+
+func NewWebhookStore(cfg config.Config) WebhookStore {
+	return WebhookStore{cfg: cfg}
+}
 
 func (s WebhookStore) List(userID string) ([]models.Webhook, error) {
 	var items []models.Webhook
@@ -39,7 +45,7 @@ func (s WebhookStore) Create(userID string, item models.Webhook) (models.Webhook
 	if item.URL == "" {
 		return models.Webhook{}, BadRequest("Webhook URL is required", nil)
 	}
-	validatedURL, err := validateWebhookURL(item.URL)
+	validatedURL, err := validateWebhookURL(item.URL, s.cfg.Webhook.AllowlistHosts)
 	if err != nil {
 		return models.Webhook{}, err
 	}
@@ -76,7 +82,7 @@ func (s WebhookStore) Update(userID, id string, input models.Webhook) (models.We
 	if input.URL == "" {
 		return models.Webhook{}, BadRequest("Webhook URL is required", nil)
 	}
-	validatedURL, err := validateWebhookURL(input.URL)
+	validatedURL, err := validateWebhookURL(input.URL, s.cfg.Webhook.AllowlistHosts)
 	if err != nil {
 		return models.Webhook{}, err
 	}
@@ -113,7 +119,7 @@ func (s WebhookStore) Delete(userID, id string) error {
 	return nil
 }
 
-func validateWebhookURL(raw string) (string, error) {
+func validateWebhookURL(raw, rawAllowlist string) (string, error) {
 	trimmed := strings.TrimSpace(raw)
 	if trimmed == "" {
 		return "", BadRequest("Webhook URL is required", nil)
@@ -129,7 +135,7 @@ func validateWebhookURL(raw string) (string, error) {
 	}
 
 	hostname := strings.ToLower(parsed.Hostname())
-	if err := validateWebhookHostname(hostname); err != nil {
+	if err := validateWebhookHostname(hostname, rawAllowlist); err != nil {
 		return "", err
 	}
 
@@ -153,11 +159,11 @@ func validateWebhookURLFormat(parsed *url.URL) error {
 	return nil
 }
 
-func validateWebhookHostname(hostname string) error {
+func validateWebhookHostname(hostname, rawAllowlist string) error {
 	if hostname == "" {
 		return BadRequest("Invalid webhook URL host", nil)
 	}
-	if err := enforceWebhookAllowlist(hostname); err != nil {
+	if err := enforceWebhookAllowlist(hostname, rawAllowlist); err != nil {
 		return err
 	}
 	if hostname == "localhost" || strings.HasSuffix(hostname, ".localhost") || strings.HasSuffix(hostname, ".local") {
@@ -202,8 +208,8 @@ func validateWebhookIP(hostname string) error {
 	return nil
 }
 
-func enforceWebhookAllowlist(hostname string) error {
-	rawAllowlist := strings.TrimSpace(os.Getenv("WEBHOOK_ALLOWLIST_HOSTS"))
+func enforceWebhookAllowlist(hostname, rawAllowlist string) error {
+	rawAllowlist = strings.TrimSpace(rawAllowlist)
 	if rawAllowlist == "" {
 		return nil
 	}

--- a/backend/internal/worker/worker.go
+++ b/backend/internal/worker/worker.go
@@ -3,10 +3,10 @@ package worker
 import (
 	"fmt"
 	"log/slog"
-	"os"
 	"strings"
 	"time"
 
+	"github.com/alpyxn/aeterna/backend/internal/config"
 	"github.com/alpyxn/aeterna/backend/internal/database"
 	"github.com/alpyxn/aeterna/backend/internal/models"
 	"github.com/alpyxn/aeterna/backend/internal/ports"
@@ -20,17 +20,20 @@ type Worker struct {
 	files    ports.FileServicePort
 	email    services.EmailService
 	webhook  services.WebhookService
+	cfg      config.Config
 }
 
 func New(
 	settings ports.SettingsServicePort,
 	webhooks ports.WebhookStorePort,
 	files ports.FileServicePort,
+	cfg config.Config,
 ) *Worker {
 	return &Worker{
 		settings: settings,
 		webhooks: webhooks,
 		files:    files,
+		cfg:      cfg,
 	}
 }
 
@@ -92,11 +95,7 @@ func (w *Worker) sendReminderEmail(settings models.Settings, msg models.Message,
 		remainingStr = fmt.Sprintf("%.0f minute(s)", remaining.Minutes())
 	}
 
-	baseURL := os.Getenv("BASE_URL")
-	if baseURL == "" {
-		baseURL = "http://localhost:5173"
-	}
-	quickLink := fmt.Sprintf("%s/api/quick-heartbeat/%s", baseURL, settings.HeartbeatToken)
+	quickLink := fmt.Sprintf("%s/api/quick-heartbeat/%s", w.cfg.Worker.BaseURL, settings.HeartbeatToken)
 
 	subject := "Check-in required"
 	body := fmt.Sprintf(`You have a scheduled message that will be sent in %s unless you confirm.


### PR DESCRIPTION
# PR Notes — Backend Config Refactor

## Summary

This PR introduces a typed config layer for the backend (`internal/config`) and removes scattered runtime reads from environment variables.  
`config.Load()` now builds a single `config.Config` object, which is injected into services, middleware, logging, database setup, and the worker.

## Why this change

- Keep configuration logic in one place.
- Catch invalid production config at startup.
- Reduce hidden runtime dependencies on `os.Getenv`.
- Make config behavior easier to test and extend.

## What changed

1. Added a modular config system:
   - `backend/internal/config/load.go`
   - `backend/internal/config/types.go`
   - `backend/internal/config/common/*`
   - `backend/internal/config/services/*`

2. Added module-level validation, including production checks for:
   - `DATABASE_PATH`
   - `ALLOWED_ORIGINS`

3. Switched these components to injected `config.Config`:
   - `database.Connect`, `database.MigrateLegacyToMultitenant`
   - `logging.Init`
   - `middleware.MasterAuth`, `middleware.SecurityHeaders`
   - `handlers.SetIsProduction`, `handlers.NewAuthHandlers`
   - `services.NewAuthService`, `NewFileService`, `NewSettingsService`, `NewWebhookStore`, `NewUserAdminService`
   - `worker.New`

4. Added test coverage for:
   - global config loading behavior
   - each config module
   - service tests impacted by config injection

5. Added backend documentation:
   - `backend/docs/config-service.md` (flow, usage, extension, Mermaid diagrams)

## Expected impact

- Fewer config inconsistencies across packages.
- Startup fails fast when required values are missing.
- Safer future additions to configuration sections.

## Review focus

- Confirm no remaining implicit runtime env reads in updated backend paths.
- Verify production deployments provide required variables.
- Verify defaults remain compatible with legacy installs.

## Validation

I did not run `go vet` or `go test` as part of this doc-only follow-up step.  
Before merge, run:

- `cd backend && go vet ./...`
- `cd backend && go test ./...`