### PR TITLE
feat(farewell): manage triggered delivery queue

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -232,6 +232,8 @@ func registerProtectedRoutes(
 	group.Post("/messages/:id/farewell-letters", farewellH.Create)
 	group.Put("/messages/:id/farewell-letters/:letterId", farewellH.Update)
 	group.Delete("/messages/:id/farewell-letters/:letterId", farewellH.Delete)
+	group.Post("/messages/:id/farewell-letters/cancel-pending", farewellH.CancelAllPending)
+	group.Post("/messages/:id/farewell-letters/:letterId/cancel", farewellH.CancelPending)
 	group.Post("/messages/:id/farewell-letters/:letterId/attachments", farewellH.UploadAttachment)
 	group.Get("/messages/:id/farewell-letters/:letterId/attachments", farewellH.ListAttachments)
 	group.Delete("/messages/:id/farewell-letters/:letterId/attachments/:attachmentId", farewellH.DeleteAttachment)

--- a/backend/internal/handlers/farewell_handler.go
+++ b/backend/internal/handlers/farewell_handler.go
@@ -122,6 +122,36 @@ func (h *FarewellHandlers) Delete(c *fiber.Ctx) error {
 	return c.JSON(fiber.Map{"success": true, "message": "Farewell letter deleted"})
 }
 
+func (h *FarewellHandlers) CancelPending(c *fiber.Ctx) error {
+	userID, err := currentUserID(c)
+	if err != nil {
+		return writeError(c, err)
+	}
+	messageID := c.Params("id")
+	letterID := c.Params("letterId")
+
+	if err := h.farewell.CancelPending(userID, messageID, letterID); err != nil {
+		return writeError(c, err)
+	}
+
+	return c.JSON(fiber.Map{"success": true, "message": "Pending farewell letter canceled"})
+}
+
+func (h *FarewellHandlers) CancelAllPending(c *fiber.Ctx) error {
+	userID, err := currentUserID(c)
+	if err != nil {
+		return writeError(c, err)
+	}
+	messageID := c.Params("id")
+
+	count, err := h.farewell.CancelPendingByMessageID(userID, messageID)
+	if err != nil {
+		return writeError(c, err)
+	}
+
+	return c.JSON(fiber.Map{"success": true, "canceled": count})
+}
+
 func (h *FarewellHandlers) UploadAttachment(c *fiber.Ctx) error {
 	userID, err := currentUserID(c)
 	if err != nil {

--- a/backend/internal/middleware/auth.go
+++ b/backend/internal/middleware/auth.go
@@ -11,6 +11,13 @@ import (
 	"github.com/gofiber/fiber/v2"
 )
 
+func unauthorizedResponse(c *fiber.Ctx) error {
+	return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+		"error": "Unauthorized access. Session required.",
+		"code":  "unauthorized",
+	})
+}
+
 // MasterAuth returns a middleware that validates the session cookie and enforces the origin allowlist.
 func MasterAuth(auth ports.AuthServicePort, cfg config.Config) fiber.Handler {
 	allowedOrigins := cfg.AllowedOriginsOrDefault()
@@ -33,10 +40,7 @@ func MasterAuth(auth ports.AuthServicePort, cfg config.Config) fiber.Handler {
 			clearSessionCookieWith(c, cookieSecureMode)
 		}
 
-		return c.Status(401).JSON(fiber.Map{
-			"error": "Unauthorized access. Session required.",
-			"code":  "unauthorized",
-		})
+		return unauthorizedResponse(c)
 	}
 }
 

--- a/backend/internal/middleware/auth_v2.go
+++ b/backend/internal/middleware/auth_v2.go
@@ -17,10 +17,7 @@ func MasterAuthV2(auth ports.AuthServicePort, cfg config.Config) fiber.Handler {
 		if token, ok := ExtractBearerToken(c.Get("Authorization")); ok {
 			userID, err := auth.VerifySessionToken(token)
 			if err != nil {
-				return c.Status(401).JSON(fiber.Map{
-					"error": "Unauthorized access. Session required.",
-					"code":  "unauthorized",
-				})
+				return unauthorizedResponse(c)
 			}
 			c.Locals("user_id", userID)
 			return c.Next()
@@ -38,9 +35,6 @@ func MasterAuthV2(auth ports.AuthServicePort, cfg config.Config) fiber.Handler {
 			clearSessionCookieWith(c, cookieSecureMode)
 		}
 
-		return c.Status(401).JSON(fiber.Map{
-			"error": "Unauthorized access. Session required.",
-			"code":  "unauthorized",
-		})
+		return unauthorizedResponse(c)
 	}
 }

--- a/backend/internal/models/message.go
+++ b/backend/internal/models/message.go
@@ -15,21 +15,23 @@ const (
 )
 
 type Message struct {
-	ID              string            `gorm:"type:text;primaryKey" json:"id"`
-	UserID          string            `gorm:"type:text;index" json:"-"`
-	Content         string            `gorm:"column:encrypted_content;not null" json:"content"`
-	KeyFragment     string            `gorm:"column:key_fragment;not null" json:"-"`
-	ManagementToken string            `gorm:"column:management_token;not null" json:"-"`
-	RecipientEmail  string            `gorm:"not null" json:"recipient_email"`
-	TriggerDuration int               `gorm:"not null" json:"trigger_duration"`
-	LastSeen        time.Time         `gorm:"not null;default:CURRENT_TIMESTAMP" json:"last_seen"`
-	Status          MessageStatus     `gorm:"default:'active'" json:"status"`
-	TriggeredAt     *time.Time        `json:"triggered_at,omitempty"`
-	Reminders       []MessageReminder `gorm:"foreignKey:MessageID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;" json:"reminders"`
-	CreatedAt       time.Time         `json:"created_at"`
-	UpdatedAt       time.Time         `json:"updated_at"`
-	DeletedAt       gorm.DeletedAt    `gorm:"index" json:"-"`
-	AttachmentCount int64             `gorm:"-" json:"attachment_count"`
+	ID               string            `gorm:"type:text;primaryKey" json:"id"`
+	UserID           string            `gorm:"type:text;index" json:"-"`
+	Content          string            `gorm:"column:encrypted_content;not null" json:"content"`
+	KeyFragment      string            `gorm:"column:key_fragment;not null" json:"-"`
+	ManagementToken  string            `gorm:"column:management_token;not null" json:"-"`
+	RecipientEmail   string            `gorm:"not null" json:"recipient_email"`
+	TriggerDuration  int               `gorm:"not null" json:"trigger_duration"`
+	LastSeen         time.Time         `gorm:"not null;default:CURRENT_TIMESTAMP" json:"last_seen"`
+	Status           MessageStatus     `gorm:"default:'active'" json:"status"`
+	TriggeredAt      *time.Time        `json:"triggered_at,omitempty"`
+	Reminders        []MessageReminder `gorm:"foreignKey:MessageID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;" json:"reminders"`
+	CreatedAt        time.Time         `json:"created_at"`
+	UpdatedAt        time.Time         `json:"updated_at"`
+	DeletedAt        gorm.DeletedAt    `gorm:"index" json:"-"`
+	AttachmentCount  int64             `gorm:"-" json:"attachment_count"`
+	FarewellCount    int64             `gorm:"-" json:"farewell_count"`
+	PendingFarewells int64             `gorm:"-" json:"pending_farewells"`
 }
 
 // BeforeCreate hook to generate UUID before creating

--- a/backend/internal/ports/ports.go
+++ b/backend/internal/ports/ports.go
@@ -52,6 +52,8 @@ type FarewellServicePort interface {
 	List(userID, messageID string) ([]models.FarewellLetter, error)
 	Update(userID, messageID, id, recipientEmail, subject, content string, delayMinutes int) (models.FarewellLetter, error)
 	Delete(userID, messageID, id string) error
+	CancelPending(userID, messageID, id string) error
+	CancelPendingByMessageID(userID, messageID string) (int64, error)
 }
 
 // SettingsServicePort covers per-user SMTP and heartbeat token configuration.

--- a/backend/internal/services/farewell_service.go
+++ b/backend/internal/services/farewell_service.go
@@ -14,13 +14,11 @@ var farewellCrypto = CryptoService{}
 var farewellValidation = ValidationService{}
 var farewellFileService = FileService{}
 
+const cancelRequiresTriggeredMessage = "Pending farewell letters can only be canceled after the switch has triggered"
+
 func (s FarewellService) Create(userID, messageID, recipientEmail, subject, content string, delayMinutes int) (models.FarewellLetter, error) {
-	var msg models.Message
-	if err := database.ForTenant(userID).First(&msg, "id = ?", messageID).Error; err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return models.FarewellLetter{}, NotFound("Message not found", err)
-		}
-		return models.FarewellLetter{}, Internal("Failed to fetch message", err)
+	if err := requireFarewellMessageNotTriggered(userID, messageID, "Cannot add farewell letters after the switch has triggered"); err != nil {
+		return models.FarewellLetter{}, err
 	}
 
 	if err := farewellValidation.ValidateEmail(recipientEmail); err != nil {
@@ -63,12 +61,8 @@ func (s FarewellService) Create(userID, messageID, recipientEmail, subject, cont
 }
 
 func (s FarewellService) List(userID, messageID string) ([]models.FarewellLetter, error) {
-	var msg models.Message
-	if err := database.ForTenant(userID).First(&msg, "id = ?", messageID).Error; err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, NotFound("Message not found", err)
-		}
-		return nil, Internal("Failed to fetch message", err)
+	if _, err := loadFarewellMessage(userID, messageID); err != nil {
+		return nil, err
 	}
 
 	var letters []models.FarewellLetter
@@ -91,6 +85,10 @@ func (s FarewellService) List(userID, messageID string) ([]models.FarewellLetter
 }
 
 func (s FarewellService) Update(userID, messageID, id, recipientEmail, subject, content string, delayMinutes int) (models.FarewellLetter, error) {
+	if err := requireFarewellMessageNotTriggered(userID, messageID, "Cannot edit farewell letters after the switch has triggered; cancel pending deliveries instead"); err != nil {
+		return models.FarewellLetter{}, err
+	}
+
 	var letter models.FarewellLetter
 	if err := database.ForTenant(userID).Where("message_id = ? AND id = ?", messageID, id).First(&letter).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -138,12 +136,19 @@ func (s FarewellService) Update(userID, messageID, id, recipientEmail, subject, 
 }
 
 func (s FarewellService) Delete(userID, messageID, id string) error {
+	if err := requireFarewellMessageNotTriggered(userID, messageID, "Cannot delete farewell letters after the switch has triggered; cancel pending deliveries instead"); err != nil {
+		return err
+	}
+
 	var letter models.FarewellLetter
 	if err := database.ForTenant(userID).Where("message_id = ? AND id = ?", messageID, id).First(&letter).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return NotFound("Farewell letter not found", err)
 		}
 		return Internal("Failed to fetch farewell letter", err)
+	}
+	if letter.Status == models.FarewellStatusSent {
+		return BadRequest("Cannot delete an already-sent farewell letter", nil)
 	}
 
 	if err := farewellFileService.DeleteFarewellAttachmentsByLetterID(userID, id); err != nil {
@@ -154,5 +159,90 @@ func (s FarewellService) Delete(userID, messageID, id string) error {
 		return Internal("Failed to delete farewell letter", err)
 	}
 
+	return nil
+}
+
+func (s FarewellService) CancelPending(userID, messageID, id string) error {
+	if err := requireFarewellMessageTriggered(userID, messageID); err != nil {
+		return err
+	}
+
+	var letter models.FarewellLetter
+	if err := database.ForTenant(userID).Where("message_id = ? AND id = ?", messageID, id).First(&letter).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return NotFound("Farewell letter not found", err)
+		}
+		return Internal("Failed to fetch farewell letter", err)
+	}
+
+	if letter.Status != models.FarewellStatusPending {
+		return BadRequest("Only pending farewell letters can be canceled", nil)
+	}
+
+	if err := farewellFileService.DeleteFarewellAttachmentsByLetterID(userID, id); err != nil {
+		return Internal("Failed to delete farewell attachments", err)
+	}
+
+	if err := database.ForTenant(userID).Unscoped().Delete(&letter).Error; err != nil {
+		return Internal("Failed to cancel farewell letter", err)
+	}
+
+	return nil
+}
+
+func (s FarewellService) CancelPendingByMessageID(userID, messageID string) (int64, error) {
+	if err := requireFarewellMessageTriggered(userID, messageID); err != nil {
+		return 0, err
+	}
+
+	var letters []models.FarewellLetter
+	if err := database.ForTenant(userID).
+		Where("message_id = ? AND status = ?", messageID, models.FarewellStatusPending).
+		Find(&letters).Error; err != nil {
+		return 0, Internal("Failed to fetch pending farewell letters", err)
+	}
+
+	for _, letter := range letters {
+		if err := farewellFileService.DeleteFarewellAttachmentsByLetterID(userID, letter.ID); err != nil {
+			return 0, Internal("Failed to delete farewell attachments", err)
+		}
+		if err := database.ForTenant(userID).Unscoped().Delete(&letter).Error; err != nil {
+			return 0, Internal("Failed to cancel farewell letter", err)
+		}
+	}
+
+	return int64(len(letters)), nil
+}
+
+func loadFarewellMessage(userID, messageID string) (models.Message, error) {
+	var msg models.Message
+	if err := database.ForTenant(userID).First(&msg, "id = ?", messageID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return models.Message{}, NotFound("Message not found", err)
+		}
+		return models.Message{}, Internal("Failed to fetch message", err)
+	}
+	return msg, nil
+}
+
+func requireFarewellMessageNotTriggered(userID, messageID, message string) error {
+	msg, err := loadFarewellMessage(userID, messageID)
+	if err != nil {
+		return err
+	}
+	if msg.Status == models.StatusTriggered {
+		return BadRequest(message, nil)
+	}
+	return nil
+}
+
+func requireFarewellMessageTriggered(userID, messageID string) error {
+	msg, err := loadFarewellMessage(userID, messageID)
+	if err != nil {
+		return err
+	}
+	if msg.Status != models.StatusTriggered {
+		return BadRequest(cancelRequiresTriggeredMessage, nil)
+	}
 	return nil
 }

--- a/backend/internal/services/farewell_service.go
+++ b/backend/internal/services/farewell_service.go
@@ -2,6 +2,9 @@ package services
 
 import (
 	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
 
 	"github.com/alpyxn/aeterna/backend/internal/database"
 	"github.com/alpyxn/aeterna/backend/internal/models"
@@ -179,13 +182,31 @@ func (s FarewellService) CancelPending(userID, messageID, id string) error {
 		return BadRequest("Only pending farewell letters can be canceled", nil)
 	}
 
-	if err := farewellFileService.DeleteFarewellAttachmentsByLetterID(userID, id); err != nil {
-		return Internal("Failed to delete farewell attachments", err)
+	var attachments []models.FarewellAttachment
+	if err := database.ForTenant(userID).Where("letter_id = ?", id).Find(&attachments).Error; err != nil {
+		return Internal("Failed to fetch farewell attachments", err)
 	}
 
-	if err := database.ForTenant(userID).Unscoped().Delete(&letter).Error; err != nil {
-		return Internal("Failed to cancel farewell letter", err)
+	if err := database.DB.Transaction(func(tx *gorm.DB) error {
+		if err := database.TenantTx(tx, userID).Unscoped().
+			Where("letter_id = ?", id).
+			Delete(&models.FarewellAttachment{}).Error; err != nil {
+			return Internal("Failed to delete farewell attachment records", err)
+		}
+		if err := database.TenantTx(tx, userID).Unscoped().Delete(&letter).Error; err != nil {
+			return Internal("Failed to cancel farewell letter", err)
+		}
+		return nil
+	}); err != nil {
+		return err
 	}
+
+	for _, att := range attachments {
+		if err := os.Remove(att.StoragePath); err != nil && !os.IsNotExist(err) {
+			slog.Error("Failed to remove farewell attachment file", "path", att.StoragePath, "error", err)
+		}
+	}
+	os.Remove(filepath.Join(farewellFileService.uploadsDir(), userID, "farewell", id))
 
 	return nil
 }
@@ -202,13 +223,50 @@ func (s FarewellService) CancelPendingByMessageID(userID, messageID string) (int
 		return 0, Internal("Failed to fetch pending farewell letters", err)
 	}
 
-	for _, letter := range letters {
-		if err := farewellFileService.DeleteFarewellAttachmentsByLetterID(userID, letter.ID); err != nil {
-			return 0, Internal("Failed to delete farewell attachments", err)
+	if len(letters) == 0 {
+		return 0, nil
+	}
+
+	letterIDs := make([]string, len(letters))
+	for i, l := range letters {
+		letterIDs[i] = l.ID
+	}
+
+	// Pre-fetch attachment records to collect file paths before any DB deletion.
+	var attachments []models.FarewellAttachment
+	if err := database.ForTenant(userID).
+		Where("letter_id IN ?", letterIDs).
+		Find(&attachments).Error; err != nil {
+		return 0, Internal("Failed to fetch farewell attachments", err)
+	}
+
+	// Delete all DB records atomically so a partial failure cannot leave orphaned rows.
+	if err := database.DB.Transaction(func(tx *gorm.DB) error {
+		if err := database.TenantTx(tx, userID).Unscoped().
+			Where("letter_id IN ?", letterIDs).
+			Delete(&models.FarewellAttachment{}).Error; err != nil {
+			return Internal("Failed to delete farewell attachment records", err)
 		}
-		if err := database.ForTenant(userID).Unscoped().Delete(&letter).Error; err != nil {
-			return 0, Internal("Failed to cancel farewell letter", err)
+		if err := database.TenantTx(tx, userID).Unscoped().
+			Where("id IN ?", letterIDs).
+			Delete(&models.FarewellLetter{}).Error; err != nil {
+			return Internal("Failed to cancel farewell letters", err)
 		}
+		return nil
+	}); err != nil {
+		return 0, err
+	}
+
+	// Filesystem cleanup runs after a successful commit; errors are logged but not fatal.
+	for _, att := range attachments {
+		if err := os.Remove(att.StoragePath); err != nil && !os.IsNotExist(err) {
+			slog.Error("Failed to remove farewell attachment file", "path", att.StoragePath, "error", err)
+		}
+	}
+	uploadsDir := farewellFileService.uploadsDir()
+	for _, id := range letterIDs {
+		letterDir := filepath.Join(uploadsDir, userID, "farewell", id)
+		os.Remove(letterDir)
 	}
 
 	return int64(len(letters)), nil

--- a/backend/internal/services/farewell_service_test.go
+++ b/backend/internal/services/farewell_service_test.go
@@ -3,6 +3,7 @@ package services
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -69,5 +70,330 @@ func TestFarewellCreate_PersistsZeroDelay(t *testing.T) {
 	}
 	if stored.DelayMinutes != 0 {
 		t.Fatalf("expected stored delay 0, got %d", stored.DelayMinutes)
+	}
+}
+
+func TestFarewellCreate_RejectsTriggeredMessage(t *testing.T) {
+	db := setupTestDB(t)
+	msg := models.Message{
+		ID:              "m-triggered-create",
+		UserID:          "u-triggered-create",
+		Content:         "encrypted",
+		KeyFragment:     "v1",
+		ManagementToken: "tok",
+		RecipientEmail:  "owner@example.com",
+		TriggerDuration: 60,
+		LastSeen:        time.Now(),
+		Status:          models.StatusTriggered,
+	}
+	if err := db.Create(&msg).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := (FarewellService{}).Create(
+		msg.UserID,
+		msg.ID,
+		"recipient@example.com",
+		"Subject",
+		"content",
+		10,
+	)
+	if err == nil || !strings.Contains(err.Error(), "Cannot add farewell letters after the switch has triggered") {
+		t.Fatalf("expected triggered create rejection, got %v", err)
+	}
+}
+
+func TestFarewellUpdate_RejectsTriggeredMessage(t *testing.T) {
+	db := setupTestDB(t)
+	msg := models.Message{
+		ID:              "m-triggered-update",
+		UserID:          "u-triggered-update",
+		Content:         "encrypted",
+		KeyFragment:     "v1",
+		ManagementToken: "tok",
+		RecipientEmail:  "owner@example.com",
+		TriggerDuration: 60,
+		LastSeen:        time.Now(),
+		Status:          models.StatusTriggered,
+	}
+	if err := db.Create(&msg).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&models.FarewellLetter{
+		ID:             "l-triggered-update",
+		UserID:         msg.UserID,
+		MessageID:      msg.ID,
+		RecipientEmail: "recipient@example.com",
+		Subject:        "Subject",
+		Content:        "encrypted",
+		DelayMinutes:   60,
+		Status:         models.FarewellStatusPending,
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := (FarewellService{}).Update(
+		msg.UserID,
+		msg.ID,
+		"l-triggered-update",
+		"recipient@example.com",
+		"Updated subject",
+		"updated content",
+		10,
+	)
+	if err == nil || !strings.Contains(err.Error(), "Cannot edit farewell letters after the switch has triggered") {
+		t.Fatalf("expected triggered update rejection, got %v", err)
+	}
+}
+
+func TestFarewellDelete_RejectsTriggeredMessage(t *testing.T) {
+	db := setupTestDB(t)
+	msg := models.Message{
+		ID:              "m-triggered-delete",
+		UserID:          "u-triggered-delete",
+		Content:         "encrypted",
+		KeyFragment:     "v1",
+		ManagementToken: "tok",
+		RecipientEmail:  "owner@example.com",
+		TriggerDuration: 60,
+		LastSeen:        time.Now(),
+		Status:          models.StatusTriggered,
+	}
+	if err := db.Create(&msg).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&models.FarewellLetter{
+		ID:             "l-triggered-delete",
+		UserID:         msg.UserID,
+		MessageID:      msg.ID,
+		RecipientEmail: "recipient@example.com",
+		Subject:        "Subject",
+		Content:        "encrypted",
+		DelayMinutes:   60,
+		Status:         models.FarewellStatusPending,
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	err := (FarewellService{}).Delete(msg.UserID, msg.ID, "l-triggered-delete")
+	if err == nil || !strings.Contains(err.Error(), "Cannot delete farewell letters after the switch has triggered") {
+		t.Fatalf("expected triggered delete rejection, got %v", err)
+	}
+}
+
+func TestFarewellCancelPending_RemovesOnlyPendingLetters(t *testing.T) {
+	db := setupTestDB(t)
+	msg := models.Message{
+		ID:              "m-cancel-pending",
+		UserID:          "u-cancel-pending",
+		Content:         "encrypted",
+		KeyFragment:     "v1",
+		ManagementToken: "tok",
+		RecipientEmail:  "owner@example.com",
+		TriggerDuration: 60,
+		LastSeen:        time.Now(),
+		Status:          models.StatusTriggered,
+	}
+	if err := db.Create(&msg).Error; err != nil {
+		t.Fatal(err)
+	}
+	for _, letter := range []models.FarewellLetter{
+		{
+			ID:             "l-pending-1",
+			UserID:         msg.UserID,
+			MessageID:      msg.ID,
+			RecipientEmail: "one@example.com",
+			Subject:        "One",
+			Content:        "encrypted",
+			DelayMinutes:   60,
+			Status:         models.FarewellStatusPending,
+		},
+		{
+			ID:             "l-pending-2",
+			UserID:         msg.UserID,
+			MessageID:      msg.ID,
+			RecipientEmail: "two@example.com",
+			Subject:        "Two",
+			Content:        "encrypted",
+			DelayMinutes:   120,
+			Status:         models.FarewellStatusPending,
+		},
+		{
+			ID:             "l-sent",
+			UserID:         msg.UserID,
+			MessageID:      msg.ID,
+			RecipientEmail: "sent@example.com",
+			Subject:        "Sent",
+			Content:        "encrypted",
+			DelayMinutes:   0,
+			Status:         models.FarewellStatusSent,
+		},
+	} {
+		if err := db.Create(&letter).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	count, err := (FarewellService{}).CancelPendingByMessageID(msg.UserID, msg.ID)
+	if err != nil {
+		t.Fatalf("CancelPendingByMessageID failed: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("expected 2 canceled letters, got %d", count)
+	}
+
+	var pendingCount int64
+	db.Model(&models.FarewellLetter{}).Where("message_id = ? AND status = ?", msg.ID, models.FarewellStatusPending).Count(&pendingCount)
+	if pendingCount != 0 {
+		t.Fatalf("expected no pending letters after cancel, got %d", pendingCount)
+	}
+	var sentCount int64
+	db.Model(&models.FarewellLetter{}).Where("message_id = ? AND status = ?", msg.ID, models.FarewellStatusSent).Count(&sentCount)
+	if sentCount != 1 {
+		t.Fatalf("expected sent letter to remain, got %d", sentCount)
+	}
+}
+
+func TestFarewellCancelPending_RejectsActiveMessage(t *testing.T) {
+	db := setupTestDB(t)
+	msg := models.Message{
+		ID:              "m-cancel-active",
+		UserID:          "u-cancel-active",
+		Content:         "encrypted",
+		KeyFragment:     "v1",
+		ManagementToken: "tok",
+		RecipientEmail:  "owner@example.com",
+		TriggerDuration: 60,
+		LastSeen:        time.Now(),
+		Status:          models.StatusActive,
+	}
+	if err := db.Create(&msg).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&models.FarewellLetter{
+		ID:             "l-cancel-active",
+		UserID:         msg.UserID,
+		MessageID:      msg.ID,
+		RecipientEmail: "one@example.com",
+		Subject:        "One",
+		Content:        "encrypted",
+		DelayMinutes:   60,
+		Status:         models.FarewellStatusPending,
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	err := (FarewellService{}).CancelPending(msg.UserID, msg.ID, "l-cancel-active")
+	if err == nil || !strings.Contains(err.Error(), cancelRequiresTriggeredMessage) {
+		t.Fatalf("expected active message cancellation rejection, got %v", err)
+	}
+
+	var count int64
+	db.Model(&models.FarewellLetter{}).Where("id = ?", "l-cancel-active").Count(&count)
+	if count != 1 {
+		t.Fatalf("expected pending letter to remain, got %d", count)
+	}
+}
+
+func TestFarewellCancelPendingByMessageID_RejectsActiveMessage(t *testing.T) {
+	db := setupTestDB(t)
+	msg := models.Message{
+		ID:              "m-cancel-all-active",
+		UserID:          "u-cancel-all-active",
+		Content:         "encrypted",
+		KeyFragment:     "v1",
+		ManagementToken: "tok",
+		RecipientEmail:  "owner@example.com",
+		TriggerDuration: 60,
+		LastSeen:        time.Now(),
+		Status:          models.StatusActive,
+	}
+	if err := db.Create(&msg).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&models.FarewellLetter{
+		ID:             "l-cancel-all-active",
+		UserID:         msg.UserID,
+		MessageID:      msg.ID,
+		RecipientEmail: "one@example.com",
+		Subject:        "One",
+		Content:        "encrypted",
+		DelayMinutes:   60,
+		Status:         models.FarewellStatusPending,
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	canceled, err := (FarewellService{}).CancelPendingByMessageID(msg.UserID, msg.ID)
+	if err == nil || !strings.Contains(err.Error(), cancelRequiresTriggeredMessage) {
+		t.Fatalf("expected active message bulk cancellation rejection, got %v", err)
+	}
+	if canceled != 0 {
+		t.Fatalf("expected no canceled letters, got %d", canceled)
+	}
+
+	var count int64
+	db.Model(&models.FarewellLetter{}).Where("id = ?", "l-cancel-all-active").Count(&count)
+	if count != 1 {
+		t.Fatalf("expected pending letter to remain, got %d", count)
+	}
+}
+
+func TestFarewellCancelPending_RemovesSinglePendingLetter(t *testing.T) {
+	db := setupTestDB(t)
+	msg := models.Message{
+		ID:              "m-cancel-one",
+		UserID:          "u-cancel-one",
+		Content:         "encrypted",
+		KeyFragment:     "v1",
+		ManagementToken: "tok",
+		RecipientEmail:  "owner@example.com",
+		TriggerDuration: 60,
+		LastSeen:        time.Now(),
+		Status:          models.StatusTriggered,
+	}
+	if err := db.Create(&msg).Error; err != nil {
+		t.Fatal(err)
+	}
+	for _, letter := range []models.FarewellLetter{
+		{
+			ID:             "l-cancel-one",
+			UserID:         msg.UserID,
+			MessageID:      msg.ID,
+			RecipientEmail: "one@example.com",
+			Subject:        "One",
+			Content:        "encrypted",
+			DelayMinutes:   60,
+			Status:         models.FarewellStatusPending,
+		},
+		{
+			ID:             "l-keep-pending",
+			UserID:         msg.UserID,
+			MessageID:      msg.ID,
+			RecipientEmail: "two@example.com",
+			Subject:        "Two",
+			Content:        "encrypted",
+			DelayMinutes:   120,
+			Status:         models.FarewellStatusPending,
+		},
+	} {
+		if err := db.Create(&letter).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := (FarewellService{}).CancelPending(msg.UserID, msg.ID, "l-cancel-one"); err != nil {
+		t.Fatalf("CancelPending failed: %v", err)
+	}
+
+	var canceledCount int64
+	db.Model(&models.FarewellLetter{}).Where("id = ?", "l-cancel-one").Count(&canceledCount)
+	if canceledCount != 0 {
+		t.Fatalf("expected selected pending letter to be removed, got %d", canceledCount)
+	}
+	var remainingCount int64
+	db.Model(&models.FarewellLetter{}).Where("id = ?", "l-keep-pending").Count(&remainingCount)
+	if remainingCount != 1 {
+		t.Fatalf("expected other pending letter to remain, got %d", remainingCount)
 	}
 }

--- a/backend/internal/services/file_service.go
+++ b/backend/internal/services/file_service.go
@@ -207,6 +207,9 @@ func (s FileService) UploadFarewellAttachment(userID, letterID, filename, mimeTy
 	if letter.Status == models.FarewellStatusSent {
 		return models.FarewellAttachment{}, BadRequest("Cannot attach files to an already-sent farewell letter", nil)
 	}
+	if err := requireFarewellMessageNotTriggered(userID, letter.MessageID, "Cannot modify farewell attachments after the switch has triggered"); err != nil {
+		return models.FarewellAttachment{}, err
+	}
 
 	cleanFilename := fileValidationService.SanitizeFilename(filename)
 	if err := fileValidationService.ValidateFarewellFile(cleanFilename, int64(len(data)), data); err != nil {
@@ -286,6 +289,16 @@ func (s FileService) DeleteFarewellAttachment(userID, attachmentID string) error
 			return NotFound("Farewell attachment not found", err)
 		}
 		return Internal("Failed to fetch farewell attachment", err)
+	}
+	var letter models.FarewellLetter
+	if err := database.ForTenant(userID).First(&letter, "id = ?", attachment.LetterID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return NotFound("Farewell letter not found", err)
+		}
+		return Internal("Failed to fetch farewell letter", err)
+	}
+	if err := requireFarewellMessageNotTriggered(userID, letter.MessageID, "Cannot modify farewell attachments after the switch has triggered"); err != nil {
+		return err
 	}
 
 	if err := os.Remove(attachment.StoragePath); err != nil && !os.IsNotExist(err) {

--- a/backend/internal/services/message_service.go
+++ b/backend/internal/services/message_service.go
@@ -153,6 +153,8 @@ func (s MessageService) List(userID string) ([]models.Message, error) {
 
 		count, _ := msgFileService.CountByMessageID(userID, messages[i].ID)
 		messages[i].AttachmentCount = count
+		database.ForTenant(userID).Model(&models.FarewellLetter{}).Where("message_id = ?", messages[i].ID).Count(&messages[i].FarewellCount)
+		database.ForTenant(userID).Model(&models.FarewellLetter{}).Where("message_id = ? AND status = ?", messages[i].ID, models.FarewellStatusPending).Count(&messages[i].PendingFarewells)
 	}
 	return messages, nil
 }

--- a/backend/internal/services/message_service.go
+++ b/backend/internal/services/message_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"errors"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -16,6 +17,17 @@ var cryptoService = CryptoService{}
 var msgValidationService = ValidationService{}
 var msgFileService = FileService{}
 var msgSettingsService = SettingsService{}
+
+type attachCountRow struct {
+	MessageID string
+	Count     int64
+}
+
+type farewellCountRow struct {
+	MessageID        string
+	Total            int64
+	PendingFarewells int64
+}
 
 func (s MessageService) Create(userID string, content string, recipientEmails []string, triggerDuration int, reminders []int) (models.Message, error) {
 	settings, err := msgSettingsService.Get(userID)
@@ -144,18 +156,57 @@ func (s MessageService) List(userID string) ([]models.Message, error) {
 	if err := database.ForTenant(userID).Preload("Reminders").Order("created_at DESC").Find(&messages).Error; err != nil {
 		return nil, Internal("Failed to fetch messages", err)
 	}
+
+	if len(messages) == 0 {
+		return messages, nil
+	}
+
+	msgIDs := make([]string, len(messages))
 	for i := range messages {
 		decrypted, err := cryptoService.Decrypt(messages[i].Content)
 		if err != nil {
 			return nil, err
 		}
 		messages[i].Content = decrypted
-
-		count, _ := msgFileService.CountByMessageID(userID, messages[i].ID)
-		messages[i].AttachmentCount = count
-		database.ForTenant(userID).Model(&models.FarewellLetter{}).Where("message_id = ?", messages[i].ID).Count(&messages[i].FarewellCount)
-		database.ForTenant(userID).Model(&models.FarewellLetter{}).Where("message_id = ? AND status = ?", messages[i].ID, models.FarewellStatusPending).Count(&messages[i].PendingFarewells)
+		msgIDs[i] = messages[i].ID
 	}
+
+	var attachCounts []attachCountRow
+	if err := database.ForTenant(userID).Model(&models.Attachment{}).
+		Select("message_id, COUNT(*) as count").
+		Where("message_id IN ?", msgIDs).
+		Group("message_id").
+		Scan(&attachCounts).Error; err != nil {
+		slog.Warn("Failed to batch-count attachments", "user_id", userID, "error", err)
+	}
+
+	attachMap := make(map[string]int64, len(attachCounts))
+	for _, r := range attachCounts {
+		attachMap[r.MessageID] = r.Count
+	}
+
+	var farewellCounts []farewellCountRow
+	if err := database.ForTenant(userID).Model(&models.FarewellLetter{}).
+		Select("message_id, COUNT(*) as total, COUNT(CASE WHEN status = ? THEN 1 END) as pending_farewells", models.FarewellStatusPending).
+		Where("message_id IN ?", msgIDs).
+		Group("message_id").
+		Scan(&farewellCounts).Error; err != nil {
+		slog.Warn("Failed to batch-count farewell letters", "user_id", userID, "error", err)
+	}
+
+	farewellMap := make(map[string]farewellCountRow, len(farewellCounts))
+	for _, r := range farewellCounts {
+		farewellMap[r.MessageID] = r
+	}
+
+	for i := range messages {
+		messages[i].AttachmentCount = attachMap[messages[i].ID]
+		if fc, ok := farewellMap[messages[i].ID]; ok {
+			messages[i].FarewellCount = fc.Total
+			messages[i].PendingFarewells = fc.PendingFarewells
+		}
+	}
+
 	return messages, nil
 }
 

--- a/backend/internal/services/message_service_delete_test.go
+++ b/backend/internal/services/message_service_delete_test.go
@@ -54,6 +54,62 @@ func TestMessageDelete_NoFarewellNoAttachments(t *testing.T) {
 	}
 }
 
+func TestMessageList_IncludesFarewellCounts(t *testing.T) {
+	db := setupTestDB(t)
+	initTestKeyManager(t)
+	encrypted, err := (CryptoService{}).Encrypt("hello")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&models.Message{
+		ID: "m-counts", UserID: "u-counts", Content: encrypted, KeyFragment: "v1",
+		ManagementToken: "tok", RecipientEmail: "a@a.com",
+		TriggerDuration: 60, LastSeen: time.Now(), Status: models.StatusTriggered,
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+	for _, letter := range []models.FarewellLetter{
+		{
+			ID:             "l-counts-pending",
+			UserID:         "u-counts",
+			MessageID:      "m-counts",
+			RecipientEmail: "pending@example.com",
+			Subject:        "Pending",
+			Content:        "encrypted",
+			DelayMinutes:   60,
+			Status:         models.FarewellStatusPending,
+		},
+		{
+			ID:             "l-counts-sent",
+			UserID:         "u-counts",
+			MessageID:      "m-counts",
+			RecipientEmail: "sent@example.com",
+			Subject:        "Sent",
+			Content:        "encrypted",
+			DelayMinutes:   0,
+			Status:         models.FarewellStatusSent,
+		},
+	} {
+		if err := db.Create(&letter).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	messages, err := (MessageService{}).List("u-counts")
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(messages))
+	}
+	if messages[0].FarewellCount != 2 {
+		t.Fatalf("expected farewell_count=2, got %d", messages[0].FarewellCount)
+	}
+	if messages[0].PendingFarewells != 1 {
+		t.Fatalf("expected pending_farewells=1, got %d", messages[0].PendingFarewells)
+	}
+}
+
 func TestMessageDelete_WithFarewellLetter(t *testing.T) {
 	db := setupTestDB(t)
 	if err := db.Create(&models.Message{

--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -102,6 +102,8 @@ export default function Dashboard() {
     const [showEditAttachments, setShowEditAttachments] = useState(false);
     const [editAttachLoading, setEditAttachLoading] = useState(false);
     const editFileInputRef = useRef(null);
+    const [queueMessage, setQueueMessage] = useState(null);
+    const [queueDialogOpen, setQueueDialogOpen] = useState(false);
 
 
     const handleEditDurationChange = (newDuration) => {
@@ -134,6 +136,11 @@ export default function Dashboard() {
         } catch {
             setEditAttachments([]);
         }
+    };
+
+    const openQueueDialog = (message) => {
+        setQueueMessage(message);
+        setQueueDialogOpen(true);
     };
 
     const addEditRecipientsFromText = (text) => {
@@ -381,6 +388,9 @@ export default function Dashboard() {
                         const recipients = parseRecipientEmails(message.recipient_email);
                         const previewRecipients = recipients.slice(0, RECIPIENT_PREVIEW_LIMIT);
                         const hasMoreRecipients = recipients.length > RECIPIENT_PREVIEW_LIMIT;
+                        const farewellCount = message.farewell_count || 0;
+                        const pendingFarewells = message.pending_farewells || 0;
+                        const canManageQueue = isTriggered && farewellCount > 0;
                         const recipientSummaryLabel = recipients.length === 0
                             ? 'No recipients'
                             : recipients.length === 1
@@ -524,6 +534,22 @@ export default function Dashboard() {
                                             disabled={actionLoading === message.id}
                                         >
                                             <Pencil className="w-4 h-4" />
+                                        </Button>
+                                    )}
+                                    {canManageQueue && (
+                                        <Button
+                                            variant="outline"
+                                            className="h-9 border-dark-700 px-3 text-xs hover:bg-amber-500/10 hover:border-amber-500/30 hover:text-amber-300"
+                                            onClick={() => openQueueDialog(message)}
+                                            disabled={actionLoading === message.id}
+                                        >
+                                            <Clock className="w-4 h-4" />
+                                            Queue
+                                            {pendingFarewells > 0 && (
+                                                <span className="ml-1 rounded bg-amber-500/10 px-1.5 py-0.5 text-[10px] text-amber-300">
+                                                    {pendingFarewells}
+                                                </span>
+                                            )}
                                         </Button>
                                     )}
                                     <AlertDialog>
@@ -797,7 +823,7 @@ export default function Dashboard() {
                         </div>
                     </div>
                     <div className="border-t border-dark-700 pt-4 mt-2">
-                        <FarewellLetters messageId={editingMessage?.id} />
+                        <FarewellLetters messageId={editingMessage?.id} onChanged={fetchMessages} />
                     </div>
                     <div className="flex flex-col-reverse sm:flex-row justify-end gap-2 mt-6">
                         <Button
@@ -817,6 +843,29 @@ export default function Dashboard() {
                             ) : null}
                             Save Changes
                         </Button>
+                    </div>
+                </DialogContent>
+            </Dialog>
+
+            <Dialog open={queueDialogOpen} onOpenChange={(open) => {
+                setQueueDialogOpen(open);
+                if (!open) setQueueMessage(null);
+            }}>
+                <DialogContent className="max-w-[95vw] sm:max-w-2xl max-h-[90vh] overflow-y-auto bg-dark-900 border-dark-700">
+                    <DialogHeader>
+                        <DialogTitle>Manage Queue</DialogTitle>
+                        <DialogDescription className="text-dark-400">
+                            {queueMessage
+                                ? `Triggered switch for ${formatRecipientEmails(queueMessage.recipient_email)}`
+                                : 'Triggered switch'}
+                        </DialogDescription>
+                    </DialogHeader>
+                    <div className="mt-4">
+                        <FarewellLetters
+                            messageId={queueMessage?.id}
+                            mode="queue"
+                            onChanged={fetchMessages}
+                        />
                     </div>
                 </DialogContent>
             </Dialog>

--- a/frontend/src/components/FarewellLetters.jsx
+++ b/frontend/src/components/FarewellLetters.jsx
@@ -6,14 +6,13 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { AlertDialog, AlertDialogTrigger, AlertDialogContent, AlertDialogTitle, AlertDialogDescription, AlertDialogCancel, AlertDialogAction } from "@/components/ui/alert-dialog";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
 import {
     Mail, Clock, Trash2, Paperclip, X, Plus, Loader2, CheckCircle,
     AlertCircle, Eye, Pencil, Upload, Send
 } from 'lucide-react';
 import {
     listFarewellLetters, createFarewellLetter, updateFarewellLetter,
-    deleteFarewellLetter, uploadFarewellAttachment,
+    deleteFarewellLetter, cancelFarewellLetter, cancelAllPendingFarewellLetters, uploadFarewellAttachment,
     listFarewellAttachments, deleteFarewellAttachment
 } from "@/lib/api";
 import { ALLOWED_EXTENSIONS, MAX_FILE_SIZE, MAX_FILES, MAX_TOTAL_SIZE, FAREWELL_DELAY_PRESETS, EMAIL_REGEX } from "@/lib/constants"
@@ -335,7 +334,7 @@ function LetterForm({ messageId, letter, onSave, onCancel }) {
     );
 }
 
-export default function FarewellLetters({ messageId }) {
+export default function FarewellLetters({ messageId, mode = 'edit', onChanged }) {
     const [letters, setLetters] = useState([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
@@ -343,6 +342,8 @@ export default function FarewellLetters({ messageId }) {
     const [showForm, setShowForm] = useState(false);
     const [toastMessage, setToastMessage] = useState('');
     const toastTimeoutRef = useRef(null);
+    const queueMode = mode === 'queue';
+    const pendingLetters = letters.filter(letter => letter.status === 'pending');
 
     const loadLetters = useCallback(async () => {
         if (!messageId) return;
@@ -392,6 +393,7 @@ export default function FarewellLetters({ messageId }) {
         });
         setShowForm(false);
         setEditingLetter(null);
+        onChanged?.();
         showToast(meta.isNewLetter ? 'Letter saved to switch' : 'Letter changes saved');
     }
 
@@ -404,6 +406,29 @@ export default function FarewellLetters({ messageId }) {
         try {
             await deleteFarewellLetter(messageId, letterId);
             setLetters(prev => prev.filter(l => l.id !== letterId));
+            onChanged?.();
+        } catch (err) {
+            setError(err.message);
+        }
+    }
+
+    async function handleCancel(letterId) {
+        try {
+            await cancelFarewellLetter(messageId, letterId);
+            setLetters(prev => prev.filter(l => l.id !== letterId));
+            onChanged?.();
+            showToast('Pending delivery canceled');
+        } catch (err) {
+            setError(err.message);
+        }
+    }
+
+    async function handleCancelAll() {
+        try {
+            const result = await cancelAllPendingFarewellLetters(messageId);
+            setLetters(prev => prev.filter(l => l.status !== 'pending'));
+            onChanged?.();
+            showToast(`${result?.canceled || 0} pending deliver${result?.canceled === 1 ? 'y' : 'ies'} canceled`);
         } catch (err) {
             setError(err.message);
         }
@@ -431,10 +456,37 @@ export default function FarewellLetters({ messageId }) {
                 <div>
                     <h3 className="text-sm font-medium text-dark-100">Farewell Letters</h3>
                     <p className="text-xs text-dark-400 mt-0.5">
-                        Personal messages sent after this switch fires, each with its own delay.
+                        {queueMode
+                            ? 'Pending deliveries can be canceled after this switch has triggered.'
+                            : 'Personal messages sent after this switch fires, each with its own delay.'}
                     </p>
                 </div>
-                {!showForm && !editingLetter && (
+                {queueMode && pendingLetters.length > 0 && (
+                    <AlertDialog>
+                        <AlertDialogTrigger asChild>
+                            <Button size="sm" variant="outline"
+                                className="border-red-500/30 bg-red-950/20 hover:bg-red-950/40 text-red-300 shrink-0">
+                                <Trash2 className="w-3 h-3 mr-1" /> Cancel all
+                            </Button>
+                        </AlertDialogTrigger>
+                        <AlertDialogContent className="bg-dark-900 border-dark-700">
+                            <AlertDialogTitle>Cancel all pending letters?</AlertDialogTitle>
+                            <AlertDialogDescription className="text-dark-400">
+                                This cancels every pending farewell letter for this triggered switch. Sent letters are not changed.
+                            </AlertDialogDescription>
+                            <div className="flex gap-2 justify-end mt-2">
+                                <AlertDialogCancel className="border-dark-700 bg-dark-900 hover:bg-dark-800 text-dark-200">
+                                    Keep queue
+                                </AlertDialogCancel>
+                                <AlertDialogAction onClick={handleCancelAll}
+                                    className="bg-red-600 hover:bg-red-500 text-white border-0">
+                                    Cancel all pending
+                                </AlertDialogAction>
+                            </div>
+                        </AlertDialogContent>
+                    </AlertDialog>
+                )}
+                {!queueMode && !showForm && !editingLetter && (
                     <Button size="sm" variant="outline" onClick={() => setShowForm(true)}
                         className="border-dark-700 bg-dark-900 hover:bg-dark-800 text-dark-200 shrink-0">
                         <Plus className="w-3 h-3 mr-1" /> Add letter
@@ -457,9 +509,18 @@ export default function FarewellLetters({ messageId }) {
                 />
             )}
 
+            {queueMode && letters.length > 0 && pendingLetters.length === 0 && (
+                <Alert className="border-teal-500/20 bg-teal-500/10">
+                    <CheckCircle className="h-4 w-4 text-teal-400" />
+                    <AlertDescription className="text-teal-200">
+                        No pending farewell deliveries remain for this switch.
+                    </AlertDescription>
+                </Alert>
+            )}
+
             {letters.length === 0 && !showForm ? (
                 <div className="text-center py-6 text-dark-500 text-xs border border-dashed border-dark-700 rounded-lg">
-                    No farewell letters configured yet.
+                    {queueMode ? 'No farewell letters are queued for this switch.' : 'No farewell letters configured yet.'}
                 </div>
             ) : (
                 <div className="space-y-2">
@@ -491,7 +552,7 @@ export default function FarewellLetters({ messageId }) {
                                             )}
                                         </div>
                                     </div>
-                                    {letter.status !== 'sent' && (
+                                    {letter.status !== 'sent' && !queueMode && (
                                         <div className="flex items-center gap-1 shrink-0">
                                             <Button size="sm" variant="ghost" onClick={() => setEditingLetter(letter)}
                                                 className="h-7 w-7 p-0 text-dark-400 hover:text-dark-100 hover:bg-dark-800">
@@ -521,6 +582,31 @@ export default function FarewellLetters({ messageId }) {
                                                 </AlertDialogContent>
                                             </AlertDialog>
                                         </div>
+                                    )}
+                                    {letter.status !== 'sent' && queueMode && (
+                                        <AlertDialog>
+                                            <AlertDialogTrigger asChild>
+                                                <Button size="sm" variant="outline"
+                                                    className="h-8 border-red-500/30 bg-red-950/20 hover:bg-red-950/40 text-red-300 shrink-0">
+                                                    <Trash2 className="w-3 h-3 mr-1" /> Cancel
+                                                </Button>
+                                            </AlertDialogTrigger>
+                                            <AlertDialogContent className="bg-dark-900 border-dark-700">
+                                                <AlertDialogTitle>Cancel pending letter?</AlertDialogTitle>
+                                                <AlertDialogDescription className="text-dark-400">
+                                                    This prevents this farewell letter from being delivered. Sent letters cannot be canceled.
+                                                </AlertDialogDescription>
+                                                <div className="flex gap-2 justify-end mt-2">
+                                                    <AlertDialogCancel className="border-dark-700 bg-dark-900 hover:bg-dark-800 text-dark-200">
+                                                        Keep letter
+                                                    </AlertDialogCancel>
+                                                    <AlertDialogAction onClick={() => handleCancel(letter.id)}
+                                                        className="bg-red-600 hover:bg-red-500 text-white border-0">
+                                                        Cancel delivery
+                                                    </AlertDialogAction>
+                                                </div>
+                                            </AlertDialogContent>
+                                        </AlertDialog>
                                     )}
                                 </div>
                             )}

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -95,6 +95,18 @@ export async function deleteFarewellLetter(messageId, letterId) {
 	});
 }
 
+export async function cancelFarewellLetter(messageId, letterId) {
+	return apiRequest(`/messages/${messageId}/farewell-letters/${letterId}/cancel`, {
+		method: "POST",
+	});
+}
+
+export async function cancelAllPendingFarewellLetters(messageId) {
+	return apiRequest(`/messages/${messageId}/farewell-letters/cancel-pending`, {
+		method: "POST",
+	});
+}
+
 export async function uploadFarewellAttachment(messageId, letterId, file) {
 	const formData = new FormData();
 	formData.append("file", file);


### PR DESCRIPTION
This is part of the follow-up fixes for the Farewell Letters flow.

Triggered switches are still not editable. The change adds a separate way to manage pending Farewell Letters after a switch has already triggered, so users can cancel delayed deliveries if the trigger happened by mistake.

## Changes

- Added a `Queue` action for triggered switches that have Farewell Letters.
- Added a `Manage Queue` view for triggered switches.
- Allowed pending Farewell Letters to be canceled one by one.
- Added `Cancel all pending` for a triggered switch.
- Kept content edits disabled after trigger.
- Kept sent Farewell Letters read-only.
- Added backend endpoints for individual and bulk cancellation.
- Added backend checks so post-trigger operations are cancellation-only.
- Added `farewell_count` and `pending_farewells` to the switch list response.
- Added tests for post-trigger restrictions, cancellation, and queue counts.

## Validation

Ran:

```bash
GOCACHE=/private/tmp/aeterna-go-cache go test ./...
GOCACHE=/private/tmp/aeterna-go-cache go vet ./...
GOCACHE=/private/tmp/aeterna-go-cache go test -race ./...
GOCACHE=/private/tmp/aeterna-go-cache go build -o /private/tmp/aeterna-server ./cmd/server
npm run lint
npm run build
git diff --cached --check
```

`golangci-lint` was attempted, but the local shim exited with code `-1` and no output. `staticcheck` and `govulncheck` were not available in PATH.

Commit:

```text
eca32f71 feat(farewell): manage triggered delivery queue
```
