### PR TITLE
feat(core): Auth Sessions, Farewell Derivation, and Message Scheduling

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -66,6 +66,7 @@ func main() {
 
 	if err := database.DB.AutoMigrate(
 		&models.User{},
+		&models.RefreshSession{},
 		&models.Message{},
 		&models.MessageReminder{},
 		&models.Settings{},
@@ -97,6 +98,9 @@ func main() {
 
 	database.DB.Exec("UPDATE messages SET encrypted_content = '' WHERE encrypted_content IS NULL;")
 	database.DB.Exec("UPDATE settings SET webhook_enabled = 0 WHERE webhook_enabled IS NULL;")
+	database.DB.Exec("UPDATE farewell_letters SET encrypted_content_raw = encrypted_content WHERE encrypted_content_raw IS NULL OR encrypted_content_raw = '';")
+	database.DB.Exec("UPDATE farewell_letters SET encrypted_rendered_html = '' WHERE encrypted_rendered_html IS NULL;")
+	database.DB.Exec("UPDATE farewell_letters SET derivatives_pending = 1 WHERE derivatives_pending IS NULL;")
 
 	if err := services.EnsureUploadsDir(cfg.Database.Path); err != nil {
 		log.Fatal("Failed to create uploads directory: ", err)
@@ -113,6 +117,7 @@ func main() {
 	appSettingsSvc := services.ApplicationSettingsService{}
 	webhookStore := services.NewWebhookStore(cfg)
 	userAdminSvc := services.NewUserAdminService(cfg)
+	farewellDerivationSvc := services.NewFarewellDerivationService()
 
 	// --- Wire handlers ---
 	authH := handlers.NewAuthHandlers(authSvc, cfg)
@@ -125,7 +130,7 @@ func main() {
 	usersH := handlers.NewUserHandlers(userAdminSvc)
 
 	// --- Wire worker ---
-	w := worker.New(settingsSvc, webhookStore, fileSvc, cfg)
+	w := worker.New(settingsSvc, webhookStore, fileSvc, farewellDerivationSvc, cfg)
 
 	app := fiber.New(fiber.Config{
 		BodyLimit: 25 * 1024 * 1024,
@@ -193,6 +198,7 @@ func main() {
 	apiV2.Post("/auth/login", middleware.AuthRateLimiter, authH.LoginV2)
 	apiV2.Post("/auth/reset-password", middleware.AuthRateLimiter, authH.ResetMasterPasswordV2)
 	apiV2.Get("/auth/session", authH.SessionStatusV2)
+	apiV2.Post("/auth/refresh", middleware.AuthRateLimiter, authH.RefreshV2)
 	apiV2.Post("/auth/logout", authH.LogoutV2)
 
 	// Protected routes

--- a/backend/internal/config/common/defaults.go
+++ b/backend/internal/config/common/defaults.go
@@ -4,7 +4,8 @@ const (
 	DefaultDatabasePath    = "./data/aeterna.db"
 	DefaultAllowedOrigins  = "http://localhost:5173"
 	DefaultWorkerBaseURL   = "http://localhost:5173"
-	DefaultSessionTTLHours = 12
+	DefaultSessionTTLHours = 168
+	DefaultRefreshTTLHours = 720
 	DefaultLogMaxSize      = 50
 	DefaultLogMaxBackups   = 5
 	DefaultLogMaxAge       = 14

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -77,6 +77,9 @@ func TestLoad_DevelopmentMode(t *testing.T) {
 	t.Setenv("DATABASE_PATH", "")
 	t.Setenv("ALLOWED_ORIGINS", "")
 	t.Setenv("PROXY_MODE", "")
+	t.Setenv("AUTH_SESSION_TTL_HOURS", "")
+	t.Setenv("AUTH_REFRESH_TTL_HOURS", "")
+	t.Setenv("BASE_URL", "")
 
 	cfg := Load()
 
@@ -88,6 +91,9 @@ func TestLoad_DevelopmentMode(t *testing.T) {
 	}
 	if cfg.Auth.SessionTTLHours != common.DefaultSessionTTLHours {
 		t.Fatalf("Auth.SessionTTLHours = %d, want %d", cfg.Auth.SessionTTLHours, common.DefaultSessionTTLHours)
+	}
+	if cfg.Auth.RefreshTTLHours != common.DefaultRefreshTTLHours {
+		t.Fatalf("Auth.RefreshTTLHours = %d, want %d", cfg.Auth.RefreshTTLHours, common.DefaultRefreshTTLHours)
 	}
 	if cfg.Worker.BaseURL != common.DefaultWorkerBaseURL {
 		t.Fatalf("Worker.BaseURL = %q, want %q", cfg.Worker.BaseURL, common.DefaultWorkerBaseURL)

--- a/backend/internal/config/services/auth_service.go
+++ b/backend/internal/config/services/auth_service.go
@@ -20,6 +20,7 @@ func init() {
 
 type AuthSection struct {
 	SessionTTLHours   int
+	RefreshTTLHours   int
 	AllowRegistration bool
 	MasterPassword    string
 	CookieSecureMode  string
@@ -35,6 +36,7 @@ func (AuthModule) LoadAndValidate() (AuthSection, error) {
 
 	return AuthSection{
 		SessionTTLHours:   common.GetPositiveInt("AUTH_SESSION_TTL_HOURS", common.DefaultSessionTTLHours),
+		RefreshTTLHours:   common.GetPositiveInt("AUTH_REFRESH_TTL_HOURS", common.DefaultRefreshTTLHours),
 		AllowRegistration: os.Getenv("ALLOW_REGISTRATION") == "true",
 		MasterPassword:    os.Getenv("MASTER_PASSWORD"),
 		CookieSecureMode:  cookieMode,

--- a/backend/internal/config/services/auth_service_test.go
+++ b/backend/internal/config/services/auth_service_test.go
@@ -19,6 +19,7 @@ func TestAuthModule_Metadata(t *testing.T) {
 func TestAuthModule_LoadAndValidate(t *testing.T) {
 	t.Run("defaults when no env vars set", func(t *testing.T) {
 		t.Setenv("AUTH_SESSION_TTL_HOURS", "")
+		t.Setenv("AUTH_REFRESH_TTL_HOURS", "")
 		t.Setenv("ALLOW_REGISTRATION", "")
 		t.Setenv("MASTER_PASSWORD", "")
 		t.Setenv("AUTH_COOKIE_SECURE_MODE", "")
@@ -28,6 +29,9 @@ func TestAuthModule_LoadAndValidate(t *testing.T) {
 		}
 		if section.SessionTTLHours != common.DefaultSessionTTLHours {
 			t.Fatalf("SessionTTLHours = %d, want %d", section.SessionTTLHours, common.DefaultSessionTTLHours)
+		}
+		if section.RefreshTTLHours != common.DefaultRefreshTTLHours {
+			t.Fatalf("RefreshTTLHours = %d, want %d", section.RefreshTTLHours, common.DefaultRefreshTTLHours)
 		}
 		if section.AllowRegistration {
 			t.Fatal("AllowRegistration should default to false")
@@ -42,6 +46,7 @@ func TestAuthModule_LoadAndValidate(t *testing.T) {
 
 	t.Run("custom session TTL", func(t *testing.T) {
 		t.Setenv("AUTH_SESSION_TTL_HOURS", "48")
+		t.Setenv("AUTH_REFRESH_TTL_HOURS", "1440")
 		section, err := AuthModule{}.LoadAndValidate()
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -49,38 +54,53 @@ func TestAuthModule_LoadAndValidate(t *testing.T) {
 		if section.SessionTTLHours != 48 {
 			t.Fatalf("SessionTTLHours = %d, want 48", section.SessionTTLHours)
 		}
+		if section.RefreshTTLHours != 1440 {
+			t.Fatalf("RefreshTTLHours = %d, want 1440", section.RefreshTTLHours)
+		}
 	})
 
 	t.Run("zero TTL falls back to default", func(t *testing.T) {
 		t.Setenv("AUTH_SESSION_TTL_HOURS", "0")
+		t.Setenv("AUTH_REFRESH_TTL_HOURS", "0")
 		section, err := AuthModule{}.LoadAndValidate()
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if section.SessionTTLHours != common.DefaultSessionTTLHours {
 			t.Fatalf("SessionTTLHours = %d, want default %d", section.SessionTTLHours, common.DefaultSessionTTLHours)
+		}
+		if section.RefreshTTLHours != common.DefaultRefreshTTLHours {
+			t.Fatalf("RefreshTTLHours = %d, want default %d", section.RefreshTTLHours, common.DefaultRefreshTTLHours)
 		}
 	})
 
 	t.Run("negative TTL falls back to default", func(t *testing.T) {
 		t.Setenv("AUTH_SESSION_TTL_HOURS", "-1")
+		t.Setenv("AUTH_REFRESH_TTL_HOURS", "-1")
 		section, err := AuthModule{}.LoadAndValidate()
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if section.SessionTTLHours != common.DefaultSessionTTLHours {
 			t.Fatalf("SessionTTLHours = %d, want default %d", section.SessionTTLHours, common.DefaultSessionTTLHours)
+		}
+		if section.RefreshTTLHours != common.DefaultRefreshTTLHours {
+			t.Fatalf("RefreshTTLHours = %d, want default %d", section.RefreshTTLHours, common.DefaultRefreshTTLHours)
 		}
 	})
 
 	t.Run("invalid TTL string falls back to default", func(t *testing.T) {
 		t.Setenv("AUTH_SESSION_TTL_HOURS", "not-a-number")
+		t.Setenv("AUTH_REFRESH_TTL_HOURS", "not-a-number")
 		section, err := AuthModule{}.LoadAndValidate()
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if section.SessionTTLHours != common.DefaultSessionTTLHours {
 			t.Fatalf("SessionTTLHours = %d, want default %d", section.SessionTTLHours, common.DefaultSessionTTLHours)
+		}
+		if section.RefreshTTLHours != common.DefaultRefreshTTLHours {
+			t.Fatalf("RefreshTTLHours = %d, want default %d", section.RefreshTTLHours, common.DefaultRefreshTTLHours)
 		}
 	})
 
@@ -118,9 +138,9 @@ func TestAuthModule_LoadAndValidate(t *testing.T) {
 	})
 
 	cookieModeTests := []struct {
-		name       string
-		input      string
-		wantMode   string
+		name     string
+		input    string
+		wantMode string
 	}{
 		{"always mode", "always", "always"},
 		{"never mode", "never", "never"},

--- a/backend/internal/handlers/auth.go
+++ b/backend/internal/handlers/auth.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"strings"
 	"time"
 
 	"github.com/alpyxn/aeterna/backend/internal/config"
@@ -25,6 +26,10 @@ type resetPasswordRequest struct {
 	Email       string `json:"email"`
 	RecoveryKey string `json:"recovery_key"`
 	NewPassword string `json:"new_password"`
+}
+
+type refreshRequest struct {
+	RefreshToken string `json:"refresh_token"`
 }
 
 type sessionMode int
@@ -184,12 +189,38 @@ func (h *AuthHandlers) SessionStatusV2(c *fiber.Ctx) error {
 	return c.JSON(fiber.Map{"authorized": true, "user_id": userID})
 }
 
+func (h *AuthHandlers) RefreshV2(c *fiber.Ctx) error {
+	var req refreshRequest
+	if len(c.Body()) > 0 {
+		if err := c.BodyParser(&req); err != nil {
+			return writeError(c, services.BadRequest("Invalid request body", err))
+		}
+	}
+	if strings.TrimSpace(req.RefreshToken) == "" {
+		return writeError(c, services.NewAPIError(401, "unauthorized", "Invalid refresh token.", nil))
+	}
+	userID, accessToken, accessExp, nextRefreshToken, nextRefreshExp, err := h.auth.RefreshSessionPair(req.RefreshToken)
+	if err != nil {
+		return writeError(c, err)
+	}
+	return c.JSON(bearerSessionPayload(userID, accessToken, accessExp, nextRefreshToken, nextRefreshExp))
+}
+
 func (h *AuthHandlers) Logout(c *fiber.Ctx) error {
 	h.clearSessionCookie(c)
 	return c.JSON(fiber.Map{"success": true})
 }
 
 func (h *AuthHandlers) LogoutV2(c *fiber.Ctx) error {
+	var req refreshRequest
+	if len(c.Body()) > 0 {
+		if err := c.BodyParser(&req); err != nil {
+			return writeError(c, services.BadRequest("Invalid request body", err))
+		}
+	}
+	if revokeErr := h.auth.RevokeRefreshToken(req.RefreshToken); revokeErr != nil {
+		return writeError(c, revokeErr)
+	}
 	h.clearSessionCookie(c)
 	return c.JSON(fiber.Map{"success": true})
 }
@@ -240,17 +271,23 @@ func (h *AuthHandlers) sessionPayload(c *fiber.Ctx, userID string, mode sessionM
 }
 
 func (h *AuthHandlers) issueSessionPayload(userID string) (fiber.Map, error) {
-	token, exp, err := h.auth.IssueSessionToken(userID)
+	accessToken, accessExp, refreshToken, refreshExp, err := h.auth.IssueSessionPair(userID)
 	if err != nil {
 		return nil, err
 	}
+	return bearerSessionPayload(userID, accessToken, accessExp, refreshToken, refreshExp), nil
+}
+
+func bearerSessionPayload(userID, accessToken string, accessExp time.Time, refreshToken string, refreshExp time.Time) fiber.Map {
 	return fiber.Map{
-		"success":      true,
-		"user_id":      userID,
-		"token_type":   "Bearer",
-		"access_token": token,
-		"expires_at":   exp.UTC().Format(time.RFC3339),
-	}, nil
+		"success":            true,
+		"user_id":            userID,
+		"token_type":         "Bearer",
+		"access_token":       accessToken,
+		"expires_at":         accessExp.UTC().Format(time.RFC3339),
+		"refresh_token":      refreshToken,
+		"refresh_expires_at": refreshExp.UTC().Format(time.RFC3339),
+	}
 }
 
 func (h *AuthHandlers) issueSessionCookie(c *fiber.Ctx, userID string) error {

--- a/backend/internal/handlers/auth_test.go
+++ b/backend/internal/handlers/auth_test.go
@@ -1,0 +1,170 @@
+package handlers
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alpyxn/aeterna/backend/internal/config"
+	"github.com/alpyxn/aeterna/backend/internal/models"
+	"github.com/alpyxn/aeterna/backend/internal/services"
+	"github.com/gofiber/fiber/v2"
+)
+
+type fakeAuthService struct {
+	verifyToken      string
+	verifyUser       string
+	verifyErr        error
+	issuedToken      string
+	issuedExp        time.Time
+	issuedRefresh    string
+	issuedRefreshExp time.Time
+	refreshToken     string
+	refreshUser      string
+	refreshErr       error
+	refreshNextToken string
+	refreshNextExp   time.Time
+	revokeErr        error
+}
+
+func (f fakeAuthService) IsConfigured() (bool, error) {
+	return false, nil
+}
+
+func (f fakeAuthService) RegisterFirstUser(email, password, ownerEmail string) (string, models.User, error) {
+	return "", models.User{}, nil
+}
+
+func (f fakeAuthService) RegisterAdditionalUser(email, password, ownerEmail string) (string, models.User, error) {
+	return "", models.User{}, nil
+}
+
+func (f fakeAuthService) Login(email, password string) (models.User, error) {
+	return models.User{}, nil
+}
+
+func (f fakeAuthService) IssueSessionToken(userID string) (string, time.Time, error) {
+	return f.issuedToken, f.issuedExp, nil
+}
+
+func (f fakeAuthService) IssueSessionPair(userID string) (string, time.Time, string, time.Time, error) {
+	return f.issuedToken, f.issuedExp, f.issuedRefresh, f.issuedRefreshExp, nil
+}
+
+func (f fakeAuthService) RefreshSessionPair(refreshToken string) (string, string, time.Time, string, time.Time, error) {
+	if f.refreshErr != nil {
+		return "", "", time.Time{}, "", time.Time{}, f.refreshErr
+	}
+	if refreshToken != f.refreshToken {
+		return "", "", time.Time{}, "", time.Time{}, services.NewAPIError(401, "unauthorized", "Invalid refresh token.", nil)
+	}
+	return f.refreshUser, f.issuedToken, f.issuedExp, f.refreshNextToken, f.refreshNextExp, nil
+}
+
+func (f fakeAuthService) RevokeRefreshToken(refreshToken string) error {
+	return f.revokeErr
+}
+
+func (f fakeAuthService) VerifySessionToken(token string) (string, error) {
+	if f.verifyErr != nil {
+		return "", f.verifyErr
+	}
+	if token != f.verifyToken {
+		return "", services.NewAPIError(401, "unauthorized", "Unauthorized access. Session required.", nil)
+	}
+	return f.verifyUser, nil
+}
+
+func (f fakeAuthService) ResetPasswordWithRecovery(email, recoveryKey, newPassword string) (string, error) {
+	return "", nil
+}
+
+func (f fakeAuthService) AdditionalRegistrationOpen() (bool, error) {
+	return false, nil
+}
+
+func TestRefreshV2IssuesNewBearerToken(t *testing.T) {
+	exp := time.Date(2026, 5, 22, 10, 30, 0, 0, time.UTC)
+	refreshExp := time.Date(2026, 6, 22, 10, 30, 0, 0, time.UTC)
+	auth := fakeAuthService{
+		refreshToken:     "old-refresh",
+		refreshUser:      "user-1",
+		issuedToken:      "new-access-token",
+		issuedExp:        exp,
+		refreshNextToken: "new-refresh-token",
+		refreshNextExp:   refreshExp,
+	}
+	app := fiber.New()
+	app.Post("/api/v2/auth/refresh", NewAuthHandlers(auth, config.Config{}).RefreshV2)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/auth/refresh", strings.NewReader(`{"refresh_token":"old-refresh"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("unexpected request error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read response: %v", err)
+	}
+	got := string(body)
+	for _, want := range []string{
+		`"success":true`,
+		`"user_id":"user-1"`,
+		`"token_type":"Bearer"`,
+		`"access_token":"new-access-token"`,
+		`"expires_at":"2026-05-22T10:30:00Z"`,
+		`"refresh_token":"new-refresh-token"`,
+		`"refresh_expires_at":"2026-06-22T10:30:00Z"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("response %s does not contain %s", got, want)
+		}
+	}
+}
+
+func TestRefreshV2RequiresRefreshToken(t *testing.T) {
+	app := fiber.New()
+	app.Post("/api/v2/auth/refresh", NewAuthHandlers(fakeAuthService{}, config.Config{}).RefreshV2)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/auth/refresh", nil)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("unexpected request error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+	}
+}
+
+func TestRefreshV2RejectsInvalidToken(t *testing.T) {
+	auth := fakeAuthService{
+		refreshErr: services.NewAPIError(401, "unauthorized", "Refresh token has expired.", errors.New("expired")),
+	}
+	app := fiber.New()
+	app.Post("/api/v2/auth/refresh", NewAuthHandlers(auth, config.Config{}).RefreshV2)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/auth/refresh", strings.NewReader(`{"refresh_token":"expired-token"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("unexpected request error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+	}
+}

--- a/backend/internal/handlers/message.go
+++ b/backend/internal/handlers/message.go
@@ -97,7 +97,12 @@ func (h *MessageHandlers) Heartbeat(c *fiber.Ctx) error {
 		return writeError(c, err)
 	}
 
-	return c.JSON(fiber.Map{"status": "alive", "last_seen": msg.LastSeen})
+	return c.JSON(fiber.Map{
+		"status":           "alive",
+		"last_seen":        msg.LastSeen,
+		"next_trigger_at":  msg.NextTriggerAt,
+		"next_reminder_at": msg.NextReminderAt,
+	})
 }
 
 func (h *MessageHandlers) List(c *fiber.Ctx) error {

--- a/backend/internal/handlers/message_test.go
+++ b/backend/internal/handlers/message_test.go
@@ -1,0 +1,164 @@
+package handlers
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alpyxn/aeterna/backend/internal/models"
+	"github.com/alpyxn/aeterna/backend/internal/services"
+	"github.com/gofiber/fiber/v2"
+)
+
+type fakeMessageService struct {
+	heartbeatResult models.Message
+	heartbeatErr    error
+}
+
+func (f fakeMessageService) Create(userID, content string, recipientEmails []string, triggerDuration int, reminders []int) (models.Message, error) {
+	return models.Message{}, nil
+}
+
+func (f fakeMessageService) GetPublicByID(id string) (models.Message, error) {
+	return models.Message{}, nil
+}
+
+func (f fakeMessageService) GetByID(userID, id string) (models.Message, error) {
+	return models.Message{}, nil
+}
+
+func (f fakeMessageService) List(userID string) ([]models.Message, error) {
+	return nil, nil
+}
+
+func (f fakeMessageService) Heartbeat(userID, id string) (models.Message, error) {
+	if f.heartbeatErr != nil {
+		return models.Message{}, f.heartbeatErr
+	}
+	return f.heartbeatResult, nil
+}
+
+func (f fakeMessageService) BulkHeartbeat(userID string) error {
+	return nil
+}
+
+func (f fakeMessageService) Delete(userID, id string) error {
+	return nil
+}
+
+func (f fakeMessageService) Update(userID, id, content string, recipientEmails []string, triggerDuration int, reminders []int) (models.Message, error) {
+	return models.Message{}, nil
+}
+
+func TestHeartbeatReturnsComputedScheduleFields(t *testing.T) {
+	lastSeen := time.Date(2026, 5, 29, 12, 0, 0, 0, time.UTC)
+	nextTrigger := lastSeen.Add(90 * time.Minute)
+	nextReminder := nextTrigger.Add(-30 * time.Minute)
+
+	handler := NewMessageHandlers(fakeMessageService{
+		heartbeatResult: models.Message{
+			LastSeen:       lastSeen,
+			NextTriggerAt:  &nextTrigger,
+			NextReminderAt: &nextReminder,
+		},
+	})
+
+	app := fiber.New()
+	app.Post("/api/heartbeat", func(c *fiber.Ctx) error {
+		c.Locals("user_id", "u-test")
+		return handler.Heartbeat(c)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/heartbeat", strings.NewReader(`{"id":"m1"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("unexpected request error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read response: %v", err)
+	}
+
+	got := string(body)
+	for _, want := range []string{
+		`"status":"alive"`,
+		`"last_seen":"2026-05-29T12:00:00Z"`,
+		`"next_trigger_at":"2026-05-29T13:30:00Z"`,
+		`"next_reminder_at":"2026-05-29T13:00:00Z"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("response %s does not contain %s", got, want)
+		}
+	}
+}
+
+func TestHeartbeatReturnsNullReminderWhenNoPendingReminder(t *testing.T) {
+	lastSeen := time.Date(2026, 5, 29, 12, 0, 0, 0, time.UTC)
+	nextTrigger := lastSeen.Add(15 * time.Minute)
+
+	handler := NewMessageHandlers(fakeMessageService{
+		heartbeatResult: models.Message{
+			LastSeen:       lastSeen,
+			NextTriggerAt:  &nextTrigger,
+			NextReminderAt: nil,
+		},
+	})
+
+	app := fiber.New()
+	app.Post("/api/heartbeat", func(c *fiber.Ctx) error {
+		c.Locals("user_id", "u-test")
+		return handler.Heartbeat(c)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/heartbeat", strings.NewReader(`{"id":"m1"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("unexpected request error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read response: %v", err)
+	}
+
+	got := string(body)
+	if !strings.Contains(got, `"next_reminder_at":null`) {
+		t.Fatalf("expected null next_reminder_at in response, got %s", got)
+	}
+}
+
+func TestHeartbeatReturnsUnauthorizedWithoutUserContext(t *testing.T) {
+	handler := NewMessageHandlers(fakeMessageService{
+		heartbeatErr: services.NewAPIError(401, "unauthorized", "Unauthorized", nil),
+	})
+	app := fiber.New()
+	app.Post("/api/heartbeat", handler.Heartbeat)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/heartbeat", strings.NewReader(`{"id":"m1"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("unexpected request error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+	}
+}

--- a/backend/internal/middleware/auth.go
+++ b/backend/internal/middleware/auth.go
@@ -34,7 +34,8 @@ func MasterAuth(auth ports.AuthServicePort, cfg config.Config) fiber.Handler {
 				if !enforceOriginAllowlist(c, allowedOrigins, isProd) {
 					return nil
 				}
-				c.Locals("user_id", userID)
+				c.Locals(LocalUserIDKey, userID)
+				c.Locals(LocalSessionKey, SessionKeyFromToken(token))
 				return c.Next()
 			}
 			clearSessionCookieWith(c, cookieSecureMode)

--- a/backend/internal/middleware/auth_v2.go
+++ b/backend/internal/middleware/auth_v2.go
@@ -19,7 +19,8 @@ func MasterAuthV2(auth ports.AuthServicePort, cfg config.Config) fiber.Handler {
 			if err != nil {
 				return unauthorizedResponse(c)
 			}
-			c.Locals("user_id", userID)
+			c.Locals(LocalUserIDKey, userID)
+			c.Locals(LocalSessionKey, SessionKeyFromToken(token))
 			return c.Next()
 		}
 
@@ -29,7 +30,8 @@ func MasterAuthV2(auth ports.AuthServicePort, cfg config.Config) fiber.Handler {
 				if !enforceOriginAllowlist(c, allowedOrigins, isProd) {
 					return nil
 				}
-				c.Locals("user_id", userID)
+				c.Locals(LocalUserIDKey, userID)
+				c.Locals(LocalSessionKey, SessionKeyFromToken(token))
 				return c.Next()
 			}
 			clearSessionCookieWith(c, cookieSecureMode)

--- a/backend/internal/middleware/request_locals.go
+++ b/backend/internal/middleware/request_locals.go
@@ -1,0 +1,8 @@
+package middleware
+
+const (
+	// LocalUserIDKey stores the authenticated user identifier in Fiber locals.
+	LocalUserIDKey = "user_id"
+	// LocalSessionKey stores a hashed request session token in Fiber locals.
+	LocalSessionKey = "session_key"
+)

--- a/backend/internal/middleware/session_key.go
+++ b/backend/internal/middleware/session_key.go
@@ -1,0 +1,17 @@
+package middleware
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+// SessionKeyFromToken returns a non-reversible stable key derived from a session token.
+func SessionKeyFromToken(token string) string {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}

--- a/backend/internal/models/farewell_letter.go
+++ b/backend/internal/models/farewell_letter.go
@@ -15,19 +15,23 @@ const (
 )
 
 type FarewellLetter struct {
-	ID              string               `gorm:"type:text;primaryKey" json:"id"`
-	UserID          string               `gorm:"type:text;index" json:"-"`
-	MessageID       string               `gorm:"type:text;not null;index" json:"message_id"`
-	RecipientEmail  string               `gorm:"not null" json:"recipient_email"`
-	Subject         string               `gorm:"not null" json:"subject"`
-	Content         string               `gorm:"column:encrypted_content;not null" json:"content"`
-	DelayMinutes    int                  `gorm:"not null" json:"delay_minutes"`
-	Status          FarewellLetterStatus `gorm:"default:'pending'" json:"status"`
-	SentAt          *time.Time           `json:"sent_at,omitempty"`
-	AttachmentCount int64                `gorm:"-" json:"attachment_count"`
-	CreatedAt       time.Time            `json:"created_at"`
-	UpdatedAt       time.Time            `json:"updated_at"`
-	DeletedAt       gorm.DeletedAt       `gorm:"index" json:"-"`
+	ID                 string               `gorm:"type:text;primaryKey" json:"id"`
+	UserID             string               `gorm:"type:text;index" json:"-"`
+	MessageID          string               `gorm:"type:text;not null;index" json:"message_id"`
+	RecipientEmail     string               `gorm:"not null" json:"recipient_email"`
+	Subject            string               `gorm:"not null" json:"subject"`
+	Content            string               `gorm:"column:encrypted_content;not null" json:"content"`
+	RawContent         string               `gorm:"column:encrypted_content_raw;not null;default:''" json:"-"`
+	RenderedHTML       string               `gorm:"column:encrypted_rendered_html;not null;default:''" json:"-"`
+	WordCount          int                  `gorm:"not null;default:0" json:"word_count"`
+	DerivativesPending bool                 `gorm:"column:derivatives_pending;not null;default:1" json:"-"`
+	DelayMinutes       int                  `gorm:"not null" json:"delay_minutes"`
+	Status             FarewellLetterStatus `gorm:"default:'pending'" json:"status"`
+	SentAt             *time.Time           `json:"sent_at,omitempty"`
+	AttachmentCount    int64                `gorm:"-" json:"attachment_count"`
+	CreatedAt          time.Time            `json:"created_at"`
+	UpdatedAt          time.Time            `json:"updated_at"`
+	DeletedAt          gorm.DeletedAt       `gorm:"index" json:"-"`
 }
 
 func (f *FarewellLetter) BeforeCreate(tx *gorm.DB) error {

--- a/backend/internal/models/farewell_letter.go
+++ b/backend/internal/models/farewell_letter.go
@@ -24,7 +24,7 @@ type FarewellLetter struct {
 	RawContent         string               `gorm:"column:encrypted_content_raw;not null;default:''" json:"-"`
 	RenderedHTML       string               `gorm:"column:encrypted_rendered_html;not null;default:''" json:"-"`
 	WordCount          int                  `gorm:"not null;default:0" json:"word_count"`
-	DerivativesPending bool                 `gorm:"column:derivatives_pending;not null;default:1" json:"-"`
+	DerivativesPending bool                 `gorm:"column:derivatives_pending;not null;default:1" json:"derivatives_pending"`
 	DelayMinutes       int                  `gorm:"not null" json:"delay_minutes"`
 	Status             FarewellLetterStatus `gorm:"default:'pending'" json:"status"`
 	SentAt             *time.Time           `json:"sent_at,omitempty"`

--- a/backend/internal/models/message.go
+++ b/backend/internal/models/message.go
@@ -25,6 +25,8 @@ type Message struct {
 	LastSeen         time.Time         `gorm:"not null;default:CURRENT_TIMESTAMP" json:"last_seen"`
 	Status           MessageStatus     `gorm:"default:'active'" json:"status"`
 	TriggeredAt      *time.Time        `json:"triggered_at,omitempty"`
+	NextTriggerAt    *time.Time        `gorm:"-" json:"next_trigger_at,omitempty"`
+	NextReminderAt   *time.Time        `gorm:"-" json:"next_reminder_at,omitempty"`
 	Reminders        []MessageReminder `gorm:"foreignKey:MessageID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;" json:"reminders"`
 	CreatedAt        time.Time         `json:"created_at"`
 	UpdatedAt        time.Time         `json:"updated_at"`

--- a/backend/internal/models/refresh_session.go
+++ b/backend/internal/models/refresh_session.go
@@ -1,0 +1,28 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// RefreshSession stores hashed refresh tokens for v2 mobile-style auth.
+type RefreshSession struct {
+	ID                  string     `gorm:"type:text;primaryKey"`
+	UserID              string     `gorm:"type:text;index;not null"`
+	User                User       `gorm:"foreignKey:UserID;references:ID;constraint:OnDelete:CASCADE;" json:"-"`
+	TokenHash           string     `gorm:"type:text;uniqueIndex;not null"`
+	ExpiresAt           time.Time  `gorm:"index;not null"`
+	RevokedAt           *time.Time `gorm:"index"`
+	ReplacedByTokenHash string     `gorm:"type:text"`
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
+}
+
+func (r *RefreshSession) BeforeCreate(tx *gorm.DB) error {
+	if r.ID == "" {
+		r.ID = uuid.NewString()
+	}
+	return nil
+}

--- a/backend/internal/ports/ports.go
+++ b/backend/internal/ports/ports.go
@@ -13,6 +13,9 @@ type AuthServicePort interface {
 	RegisterAdditionalUser(email, password, ownerEmail string) (recoveryKey string, user models.User, err error)
 	Login(email, password string) (models.User, error)
 	IssueSessionToken(userID string) (string, time.Time, error)
+	IssueSessionPair(userID string) (accessToken string, accessExp time.Time, refreshToken string, refreshExp time.Time, err error)
+	RefreshSessionPair(refreshToken string) (userID, accessToken string, accessExp time.Time, nextRefreshToken string, nextRefreshExp time.Time, err error)
+	RevokeRefreshToken(refreshToken string) error
 	VerifySessionToken(token string) (userID string, err error)
 	ResetPasswordWithRecovery(email, recoveryKey, newPassword string) (newRecoveryKey string, err error)
 	AdditionalRegistrationOpen() (bool, error)
@@ -54,6 +57,11 @@ type FarewellServicePort interface {
 	Delete(userID, messageID, id string) error
 	CancelPending(userID, messageID, id string) error
 	CancelPendingByMessageID(userID, messageID string) (int64, error)
+}
+
+// FarewellDerivationPort covers background derivation of sanitized/rendered farewell content.
+type FarewellDerivationPort interface {
+	ProcessPending(batchSize int) (processed int, err error)
 }
 
 // SettingsServicePort covers per-user SMTP and heartbeat token configuration.

--- a/backend/internal/services/auth_constants.go
+++ b/backend/internal/services/auth_constants.go
@@ -1,0 +1,5 @@
+package services
+
+import "time"
+
+const refreshRevokedRetention = 24 * time.Hour

--- a/backend/internal/services/auth_service.go
+++ b/backend/internal/services/auth_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/hex"
 	"encoding/json"
@@ -11,6 +12,7 @@ import (
 	"time"
 
 	"github.com/alpyxn/aeterna/backend/internal/config"
+	"github.com/alpyxn/aeterna/backend/internal/config/common"
 	"github.com/alpyxn/aeterna/backend/internal/database"
 	"github.com/alpyxn/aeterna/backend/internal/models"
 	"golang.org/x/crypto/bcrypt"
@@ -30,6 +32,19 @@ type sessionClaims struct {
 	Iat    int64  `json:"iat"`
 	UserID string `json:"uid"`
 	Hash   string `json:"hash,omitempty"`
+}
+
+func (s AuthService) refreshTTL() time.Duration {
+	ttlHours := s.cfg.Auth.RefreshTTLHours
+	if ttlHours <= 0 {
+		ttlHours = common.DefaultRefreshTTLHours
+	}
+	return time.Duration(ttlHours) * time.Hour
+}
+
+func refreshTokenHash(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
 }
 
 func (s AuthService) passwordHashPrefixForUser(userID string) (string, error) {
@@ -76,6 +91,123 @@ func (s AuthService) IssueSessionToken(userID string) (string, time.Time, error)
 	return token, exp, nil
 }
 
+func (s AuthService) IssueSessionPair(userID string) (accessToken string, accessExp time.Time, refreshToken string, refreshExp time.Time, err error) {
+	accessToken, accessExp, err = s.IssueSessionToken(userID)
+	if err != nil {
+		return "", time.Time{}, "", time.Time{}, err
+	}
+	refreshToken, refreshExp, err = s.issueRefreshSession(database.DB, userID)
+	if err != nil {
+		return "", time.Time{}, "", time.Time{}, err
+	}
+	return accessToken, accessExp, refreshToken, refreshExp, nil
+}
+
+func (s AuthService) RefreshSessionPair(refreshToken string) (userID, accessToken string, accessExp time.Time, nextRefreshToken string, nextRefreshExp time.Time, err error) {
+	refreshToken = strings.TrimSpace(refreshToken)
+	if refreshToken == "" {
+		return "", "", time.Time{}, "", time.Time{}, NewAPIError(401, "unauthorized", "Invalid refresh token.", nil)
+	}
+
+	currentHash := refreshTokenHash(refreshToken)
+	var current models.RefreshSession
+	if err := database.DB.Where("token_hash = ?", currentHash).First(&current).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return "", "", time.Time{}, "", time.Time{}, NewAPIError(401, "unauthorized", "Invalid refresh token.", nil)
+		}
+		return "", "", time.Time{}, "", time.Time{}, Internal("Failed to load refresh session", err)
+	}
+	if current.RevokedAt != nil {
+		return "", "", time.Time{}, "", time.Time{}, NewAPIError(401, "unauthorized", "Refresh token has been revoked.", nil)
+	}
+	if time.Now().UTC().After(current.ExpiresAt) {
+		return "", "", time.Time{}, "", time.Time{}, NewAPIError(401, "unauthorized", "Refresh token has expired.", nil)
+	}
+
+	accessToken, accessExp, err = s.IssueSessionToken(current.UserID)
+	if err != nil {
+		return "", "", time.Time{}, "", time.Time{}, err
+	}
+
+	userID = current.UserID
+	err = database.DB.Transaction(func(tx *gorm.DB) error {
+		now := time.Now().UTC()
+		revokeResult := tx.Model(&models.RefreshSession{}).
+			Where("id = ? AND revoked_at IS NULL AND expires_at > ?", current.ID, now).
+			Update("revoked_at", now)
+		if revokeResult.Error != nil {
+			return Internal("Failed to revoke refresh session", revokeResult.Error)
+		}
+		if revokeResult.RowsAffected != 1 {
+			return NewAPIError(401, "unauthorized", "Invalid refresh token.", nil)
+		}
+
+		token, exp, issueErr := s.issueRefreshSession(tx, current.UserID)
+		if issueErr != nil {
+			return issueErr
+		}
+		nextRefreshToken = token
+		nextRefreshExp = exp
+
+		current.ReplacedByTokenHash = refreshTokenHash(nextRefreshToken)
+		if err := tx.Model(&models.RefreshSession{}).
+			Where("id = ?", current.ID).
+			Update("replaced_by_token_hash", current.ReplacedByTokenHash).Error; err != nil {
+			return Internal("Failed to link rotated refresh session", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return "", "", time.Time{}, "", time.Time{}, err
+	}
+
+	return userID, accessToken, accessExp, nextRefreshToken, nextRefreshExp, nil
+}
+
+func (s AuthService) RevokeRefreshToken(refreshToken string) error {
+	refreshToken = strings.TrimSpace(refreshToken)
+	if refreshToken == "" {
+		return nil
+	}
+	hash := refreshTokenHash(refreshToken)
+	now := time.Now().UTC()
+	return database.DB.Transaction(func(tx *gorm.DB) error {
+		var session models.RefreshSession
+		if err := tx.Where("token_hash = ?", hash).First(&session).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil
+			}
+			return Internal("Failed to load refresh session", err)
+		}
+		if session.RevokedAt != nil {
+			return nil
+		}
+		if err := tx.Model(&models.RefreshSession{}).
+			Where("id = ?", session.ID).
+			Update("revoked_at", now).Error; err != nil {
+			return Internal("Failed to revoke refresh session", err)
+		}
+		return nil
+	})
+}
+
+func (s AuthService) issueRefreshSession(db *gorm.DB, userID string) (string, time.Time, error) {
+	token, err := cryptoService.GenerateToken(48)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	exp := time.Now().UTC().Add(s.refreshTTL())
+	record := models.RefreshSession{
+		UserID:    userID,
+		TokenHash: refreshTokenHash(token),
+		ExpiresAt: exp,
+	}
+	if err := db.Create(&record).Error; err != nil {
+		return "", time.Time{}, Internal("Failed to create refresh session", err)
+	}
+	return token, exp, nil
+}
+
 // VerifySessionToken validates the cookie token and returns the authenticated user ID.
 func (s AuthService) VerifySessionToken(token string) (userID string, err error) {
 	if token == "" {
@@ -114,7 +246,11 @@ func (s AuthService) VerifySessionToken(token string) (userID string, err error)
 }
 
 func (s AuthService) sessionTTL() time.Duration {
-	return time.Duration(s.cfg.Auth.SessionTTLHours) * time.Hour
+	ttlHours := s.cfg.Auth.SessionTTLHours
+	if ttlHours <= 0 {
+		ttlHours = common.DefaultSessionTTLHours
+	}
+	return time.Duration(ttlHours) * time.Hour
 }
 
 // IsConfigured returns true when at least one user account exists.
@@ -400,6 +536,11 @@ func (s AuthService) ResetPasswordWithRecovery(email, recoveryKey, newPassword s
 	}
 	if err := database.DB.Save(&settings).Error; err != nil {
 		return "", Internal("Failed to update recovery key", err)
+	}
+	if err := database.DB.Model(&models.RefreshSession{}).
+		Where("user_id = ? AND revoked_at IS NULL", user.ID).
+		Update("revoked_at", time.Now().UTC()).Error; err != nil {
+		return "", Internal("Failed to revoke refresh sessions", err)
 	}
 
 	return newRec, nil

--- a/backend/internal/services/auth_service.go
+++ b/backend/internal/services/auth_service.go
@@ -192,6 +192,10 @@ func (s AuthService) RevokeRefreshToken(refreshToken string) error {
 }
 
 func (s AuthService) issueRefreshSession(db *gorm.DB, userID string) (string, time.Time, error) {
+	if err := s.cleanupRefreshSessions(db, time.Now().UTC()); err != nil {
+		return "", time.Time{}, err
+	}
+
 	token, err := cryptoService.GenerateToken(48)
 	if err != nil {
 		return "", time.Time{}, err
@@ -206,6 +210,18 @@ func (s AuthService) issueRefreshSession(db *gorm.DB, userID string) (string, ti
 		return "", time.Time{}, Internal("Failed to create refresh session", err)
 	}
 	return token, exp, nil
+}
+
+func (s AuthService) cleanupRefreshSessions(db *gorm.DB, now time.Time) error {
+	revokedCutoff := now.Add(-refreshRevokedRetention)
+	if err := db.Where(
+		"expires_at <= ? OR (revoked_at IS NOT NULL AND revoked_at <= ?)",
+		now,
+		revokedCutoff,
+	).Delete(&models.RefreshSession{}).Error; err != nil {
+		return Internal("Failed to cleanup refresh sessions", err)
+	}
+	return nil
 }
 
 // VerifySessionToken validates the cookie token and returns the authenticated user ID.

--- a/backend/internal/services/auth_service_test.go
+++ b/backend/internal/services/auth_service_test.go
@@ -1,10 +1,19 @@
 package services
 
 import (
+	"fmt"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/alpyxn/aeterna/backend/internal/config"
+	"github.com/alpyxn/aeterna/backend/internal/config/common"
+	"github.com/alpyxn/aeterna/backend/internal/database"
+	"github.com/alpyxn/aeterna/backend/internal/models"
+	"golang.org/x/crypto/bcrypt"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
 )
 
 func TestSessionTTL(t *testing.T) {
@@ -13,10 +22,13 @@ func TestSessionTTL(t *testing.T) {
 		hours int
 		want  time.Duration
 	}{
+		{"default mobile app window", common.DefaultSessionTTLHours, 168 * time.Hour},
 		{"twelve hours", 12, 12 * time.Hour},
 		{"six hours", 6, 6 * time.Hour},
 		{"one hour", 1, time.Hour},
 		{"large value", 720, 720 * time.Hour},
+		{"zero falls back to default", 0, time.Duration(common.DefaultSessionTTLHours) * time.Hour},
+		{"negative falls back to default", -4, time.Duration(common.DefaultSessionTTLHours) * time.Hour},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -25,5 +37,163 @@ func TestSessionTTL(t *testing.T) {
 				t.Fatalf("expected %v, got %v", tc.want, got)
 			}
 		})
+	}
+}
+
+func setupAuthTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	replacer := strings.NewReplacer("/", "_", " ", "_")
+	dsn := fmt.Sprintf("file:%s_%d?mode=memory&cache=shared&_foreign_keys=1", replacer.Replace(t.Name()), time.Now().UnixNano())
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&models.User{}, &models.RefreshSession{}); err != nil {
+		t.Fatal(err)
+	}
+	prev := database.DB
+	database.DB = db
+	t.Cleanup(func() { database.DB = prev })
+	return db
+}
+
+func createAuthTestUser(t *testing.T, db *gorm.DB, id, email, password string) models.User {
+	t.Helper()
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		t.Fatal(err)
+	}
+	user := models.User{
+		ID:           id,
+		Email:        email,
+		PasswordHash: string(hash),
+	}
+	if err := db.Create(&user).Error; err != nil {
+		t.Fatal(err)
+	}
+	return user
+}
+
+func TestRefreshTTL(t *testing.T) {
+	tests := []struct {
+		name  string
+		hours int
+		want  time.Duration
+	}{
+		{"default refresh window", common.DefaultRefreshTTLHours, 720 * time.Hour},
+		{"custom refresh window", 336, 336 * time.Hour},
+		{"zero falls back to default", 0, time.Duration(common.DefaultRefreshTTLHours) * time.Hour},
+		{"negative falls back to default", -4, time.Duration(common.DefaultRefreshTTLHours) * time.Hour},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := NewAuthService(config.Config{Auth: config.AuthConfig{RefreshTTLHours: tc.hours}})
+			if got := svc.refreshTTL(); got != tc.want {
+				t.Fatalf("expected %v, got %v", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestIssueAndRefreshSessionPair_RotatesRefreshToken(t *testing.T) {
+	db := setupAuthTestDB(t)
+	initTestKeyManager(t)
+	user := createAuthTestUser(t, db, "u1", "user@example.com", "StrongPass1!")
+
+	svc := NewAuthService(config.Config{
+		Auth: config.AuthConfig{
+			SessionTTLHours: 1,
+			RefreshTTLHours: 24,
+		},
+	})
+
+	accessToken, accessExp, refreshToken, refreshExp, err := svc.IssueSessionPair(user.ID)
+	if err != nil {
+		t.Fatalf("IssueSessionPair failed: %v", err)
+	}
+	if accessToken == "" || refreshToken == "" {
+		t.Fatal("expected non-empty access and refresh tokens")
+	}
+	if !accessExp.After(time.Now().UTC()) || !refreshExp.After(time.Now().UTC()) {
+		t.Fatal("expected token expirations in the future")
+	}
+	if gotUserID, verifyErr := svc.VerifySessionToken(accessToken); verifyErr != nil || gotUserID != user.ID {
+		t.Fatalf("VerifySessionToken failed: user=%q err=%v", gotUserID, verifyErr)
+	}
+
+	userID, nextAccess, nextAccessExp, nextRefresh, nextRefreshExp, err := svc.RefreshSessionPair(refreshToken)
+	if err != nil {
+		t.Fatalf("RefreshSessionPair failed: %v", err)
+	}
+	if userID != user.ID {
+		t.Fatalf("expected user %q, got %q", user.ID, userID)
+	}
+	if nextAccess == "" || nextRefresh == "" {
+		t.Fatal("expected rotated non-empty tokens")
+	}
+	if nextRefresh == refreshToken {
+		t.Fatal("expected rotated refresh token to differ from previous one")
+	}
+	if !nextAccessExp.After(time.Now().UTC()) || !nextRefreshExp.After(time.Now().UTC()) {
+		t.Fatal("expected rotated expirations in the future")
+	}
+
+	if _, _, _, _, _, err := svc.RefreshSessionPair(refreshToken); err == nil {
+		t.Fatal("expected old refresh token to be rejected after rotation")
+	}
+	if err := svc.RevokeRefreshToken(nextRefresh); err != nil {
+		t.Fatalf("RevokeRefreshToken failed: %v", err)
+	}
+	if _, _, _, _, _, err := svc.RefreshSessionPair(nextRefresh); err == nil {
+		t.Fatal("expected revoked refresh token to be rejected")
+	}
+}
+
+func TestRefreshSessionPair_AllowsSingleConcurrentUse(t *testing.T) {
+	db := setupAuthTestDB(t)
+	initTestKeyManager(t)
+	user := createAuthTestUser(t, db, "u2", "user2@example.com", "StrongPass1!")
+
+	svc := NewAuthService(config.Config{
+		Auth: config.AuthConfig{
+			SessionTTLHours: 1,
+			RefreshTTLHours: 24,
+		},
+	})
+
+	_, _, refreshToken, _, err := svc.IssueSessionPair(user.ID)
+	if err != nil {
+		t.Fatalf("IssueSessionPair failed: %v", err)
+	}
+
+	start := make(chan struct{})
+	results := make(chan error, 2)
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, _, _, _, _, refreshErr := svc.RefreshSessionPair(refreshToken)
+			results <- refreshErr
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(results)
+
+	successes := 0
+	failures := 0
+	for refreshErr := range results {
+		if refreshErr == nil {
+			successes++
+			continue
+		}
+		failures++
+	}
+
+	if successes != 1 || failures != 1 {
+		t.Fatalf("expected exactly one success and one failure, got successes=%d failures=%d", successes, failures)
 	}
 }

--- a/backend/internal/services/auth_service_test.go
+++ b/backend/internal/services/auth_service_test.go
@@ -197,3 +197,87 @@ func TestRefreshSessionPair_AllowsSingleConcurrentUse(t *testing.T) {
 		t.Fatalf("expected exactly one success and one failure, got successes=%d failures=%d", successes, failures)
 	}
 }
+
+func TestIssueSessionPair_CleansUpExpiredAndOldRevokedSessions(t *testing.T) {
+	db := setupAuthTestDB(t)
+	initTestKeyManager(t)
+
+	activeUser := createAuthTestUser(t, db, "u-clean-active", "active@example.com", "StrongPass1!")
+	otherUser := createAuthTestUser(t, db, "u-clean-other", "other@example.com", "StrongPass1!")
+	now := time.Now().UTC()
+	oldRevokedAt := now.Add(-48 * time.Hour)
+	recentRevokedAt := now.Add(-2 * time.Hour)
+
+	sessions := []models.RefreshSession{
+		{
+			UserID:    activeUser.ID,
+			TokenHash: "cleanup-expired",
+			ExpiresAt: now.Add(-1 * time.Hour),
+		},
+		{
+			UserID:    activeUser.ID,
+			TokenHash: "cleanup-old-revoked",
+			ExpiresAt: now.Add(24 * time.Hour),
+			RevokedAt: &oldRevokedAt,
+		},
+		{
+			UserID:    activeUser.ID,
+			TokenHash: "cleanup-recent-revoked",
+			ExpiresAt: now.Add(24 * time.Hour),
+			RevokedAt: &recentRevokedAt,
+		},
+		{
+			UserID:    otherUser.ID,
+			TokenHash: "cleanup-other-user-active",
+			ExpiresAt: now.Add(24 * time.Hour),
+		},
+	}
+	for _, session := range sessions {
+		if err := db.Create(&session).Error; err != nil {
+			t.Fatalf("failed to seed refresh session %q: %v", session.TokenHash, err)
+		}
+	}
+
+	svc := NewAuthService(config.Config{
+		Auth: config.AuthConfig{
+			SessionTTLHours: 1,
+			RefreshTTLHours: 24,
+		},
+	})
+
+	if _, _, _, _, err := svc.IssueSessionPair(activeUser.ID); err != nil {
+		t.Fatalf("IssueSessionPair failed: %v", err)
+	}
+
+	var expiredCount int64
+	if err := db.Model(&models.RefreshSession{}).Where("token_hash = ?", "cleanup-expired").Count(&expiredCount).Error; err != nil {
+		t.Fatal(err)
+	}
+	if expiredCount != 0 {
+		t.Fatalf("expected expired refresh session to be deleted, found %d rows", expiredCount)
+	}
+
+	var oldRevokedCount int64
+	if err := db.Model(&models.RefreshSession{}).Where("token_hash = ?", "cleanup-old-revoked").Count(&oldRevokedCount).Error; err != nil {
+		t.Fatal(err)
+	}
+	if oldRevokedCount != 0 {
+		t.Fatalf("expected old revoked refresh session to be deleted, found %d rows", oldRevokedCount)
+	}
+
+	var recentRevokedCount int64
+	if err := db.Model(&models.RefreshSession{}).Where("token_hash = ?", "cleanup-recent-revoked").Count(&recentRevokedCount).Error; err != nil {
+		t.Fatal(err)
+	}
+	if recentRevokedCount != 1 {
+		t.Fatalf("expected recent revoked refresh session to remain, found %d rows", recentRevokedCount)
+	}
+
+	var otherActiveCount int64
+	if err := db.Model(&models.RefreshSession{}).Where("token_hash = ?", "cleanup-other-user-active").Count(&otherActiveCount).Error; err != nil {
+		t.Fatal(err)
+	}
+	if otherActiveCount != 1 {
+		t.Fatalf("expected active session for another user to remain, found %d rows", otherActiveCount)
+	}
+}

--- a/backend/internal/services/email_farewell.go
+++ b/backend/internal/services/email_farewell.go
@@ -1,0 +1,139 @@
+package services
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"mime"
+	"strings"
+
+	"github.com/alpyxn/aeterna/backend/internal/models"
+	"github.com/gomarkdown/markdown"
+	"github.com/gomarkdown/markdown/html"
+	"github.com/gomarkdown/markdown/parser"
+)
+
+// markdownToHTML converts Markdown content to an HTML string.
+func markdownToHTML(md string) string {
+	extensions := parser.CommonExtensions | parser.AutoHeadingIDs
+	p := parser.NewWithExtensions(extensions)
+	doc := p.Parse([]byte(md))
+
+	// Harden rendered HTML:
+	// - Drop raw HTML from user markdown
+	// - Allow only safe links
+	// - Add rel attributes for external links
+	opts := html.RendererOptions{
+		Flags: html.CommonFlags |
+			html.HrefTargetBlank |
+			html.SkipHTML |
+			html.Safelink |
+			html.NofollowLinks |
+			html.NoreferrerLinks |
+			html.NoopenerLinks,
+	}
+	renderer := html.NewRenderer(opts)
+
+	return string(markdown.Render(doc, renderer))
+}
+
+// SendFarewellLetter sends a farewell letter as a multipart HTML email with optional attachments.
+// The content is written in Markdown and rendered to HTML; plain text is sent as fallback.
+func (s EmailService) SendFarewellLetter(settings models.Settings, recipientEmail, subject, mdContent string, attachments []EmailAttachment) error {
+	htmlBody := markdownToHTML(mdContent)
+	plainBody := markdownToPlainText(mdContent)
+	if plainBody == "" {
+		plainBody = mdContent
+	}
+	return s.sendFarewellLetterWithBodies(settings, recipientEmail, subject, plainBody, htmlBody, attachments)
+}
+
+func (s EmailService) SendFarewellLetterPreRendered(settings models.Settings, recipientEmail, subject, safeMarkdown, renderedHTML string, attachments []EmailAttachment) error {
+	plainBody := markdownToPlainText(safeMarkdown)
+	if plainBody == "" {
+		plainBody = safeMarkdown
+	}
+	htmlBody := renderedHTML
+	if strings.TrimSpace(htmlBody) == "" {
+		htmlBody = markdownToHTML(safeMarkdown)
+	}
+	return s.sendFarewellLetterWithBodies(settings, recipientEmail, subject, plainBody, htmlBody, attachments)
+}
+
+func (s EmailService) sendFarewellLetterWithBodies(settings models.Settings, recipientEmail, subject, plainBody, htmlBody string, attachments []EmailAttachment) error {
+	from := settings.SMTPFrom
+	if from == "" {
+		from = settings.SMTPUser
+	}
+	fromName := settings.SMTPFromName
+	if fromName == "" {
+		fromName = "Aeterna"
+	}
+
+	from = sanitizeEmailHeader(from)
+	fromName = sanitizeEmailHeader(fromName)
+	subject = sanitizeEmailHeader(subject)
+	recipient := sanitizeEmailHeader(recipientEmail)
+
+	outerBoundary := "==AeternaFarewellMixed=="
+	altBoundary := "==AeternaFarewellAlt=="
+
+	var buf bytes.Buffer
+
+	buf.WriteString(fmt.Sprintf("From: %s <%s>\r\n", fromName, from))
+	buf.WriteString(fmt.Sprintf("To: %s\r\n", recipient))
+	buf.WriteString(fmt.Sprintf("Subject: %s\r\n", subject))
+	buf.WriteString("MIME-Version: 1.0\r\n")
+
+	if len(attachments) > 0 {
+		// multipart/mixed wrapping multipart/alternative + attachments
+		buf.WriteString(fmt.Sprintf("Content-Type: multipart/mixed; boundary=\"%s\"\r\n\r\n", outerBoundary))
+
+		buf.WriteString(fmt.Sprintf("--%s\r\n", outerBoundary))
+		buf.WriteString(fmt.Sprintf("Content-Type: multipart/alternative; boundary=\"%s\"\r\n\r\n", altBoundary))
+
+		writeAlternativeParts(&buf, altBoundary, plainBody, htmlBody)
+
+		buf.WriteString(fmt.Sprintf("--%s--\r\n", altBoundary))
+		buf.WriteString("\r\n")
+
+		for _, att := range attachments {
+			buf.WriteString(fmt.Sprintf("--%s\r\n", outerBoundary))
+			buf.WriteString(fmt.Sprintf("Content-Type: %s; name=\"%s\"\r\n", att.MimeType, mime.QEncoding.Encode("utf-8", att.Filename)))
+			buf.WriteString("Content-Transfer-Encoding: base64\r\n")
+			buf.WriteString(fmt.Sprintf("Content-Disposition: attachment; filename=\"%s\"\r\n\r\n", mime.QEncoding.Encode("utf-8", att.Filename)))
+			encoded := base64.StdEncoding.EncodeToString(att.Data)
+			for i := 0; i < len(encoded); i += 76 {
+				end := i + 76
+				if end > len(encoded) {
+					end = len(encoded)
+				}
+				buf.WriteString(encoded[i:end])
+				buf.WriteString("\r\n")
+			}
+		}
+		buf.WriteString(fmt.Sprintf("--%s--\r\n", outerBoundary))
+	} else {
+		// multipart/alternative only
+		buf.WriteString(fmt.Sprintf("Content-Type: multipart/alternative; boundary=\"%s\"\r\n\r\n", altBoundary))
+		writeAlternativeParts(&buf, altBoundary, plainBody, htmlBody)
+		buf.WriteString(fmt.Sprintf("--%s--\r\n", altBoundary))
+	}
+
+	message := buf.Bytes()
+	return s.sendRaw(settings, from, []string{recipient}, message)
+}
+
+func writeAlternativeParts(buf *bytes.Buffer, boundary, plainBody, htmlBody string) {
+	buf.WriteString(fmt.Sprintf("--%s\r\n", boundary))
+	buf.WriteString("Content-Type: text/plain; charset=UTF-8\r\n")
+	buf.WriteString("Content-Transfer-Encoding: 7bit\r\n\r\n")
+	buf.WriteString(plainBody)
+	buf.WriteString("\r\n")
+
+	buf.WriteString(fmt.Sprintf("--%s\r\n", boundary))
+	buf.WriteString("Content-Type: text/html; charset=UTF-8\r\n")
+	buf.WriteString("Content-Transfer-Encoding: 7bit\r\n\r\n")
+	buf.WriteString(htmlBody)
+	buf.WriteString("\r\n")
+}

--- a/backend/internal/services/email_service.go
+++ b/backend/internal/services/email_service.go
@@ -12,9 +12,6 @@ import (
 	"time"
 
 	"github.com/alpyxn/aeterna/backend/internal/models"
-	"github.com/gomarkdown/markdown"
-	"github.com/gomarkdown/markdown/html"
-	"github.com/gomarkdown/markdown/parser"
 )
 
 type EmailService struct{}
@@ -340,101 +337,6 @@ func ParseRecipientEmails(value string) []string {
 		return nil
 	}
 	return result
-}
-
-// markdownToHTML converts Markdown content to an HTML string.
-func markdownToHTML(md string) string {
-	extensions := parser.CommonExtensions | parser.AutoHeadingIDs
-	p := parser.NewWithExtensions(extensions)
-	doc := p.Parse([]byte(md))
-
-	opts := html.RendererOptions{Flags: html.CommonFlags | html.HrefTargetBlank}
-	renderer := html.NewRenderer(opts)
-
-	return string(markdown.Render(doc, renderer))
-}
-
-// SendFarewellLetter sends a farewell letter as a multipart HTML email with optional attachments.
-// The content is written in Markdown and rendered to HTML; plain text is sent as fallback.
-func (s EmailService) SendFarewellLetter(settings models.Settings, recipientEmail, subject, mdContent string, attachments []EmailAttachment) error {
-	from := settings.SMTPFrom
-	if from == "" {
-		from = settings.SMTPUser
-	}
-	fromName := settings.SMTPFromName
-	if fromName == "" {
-		fromName = "Aeterna"
-	}
-
-	from = sanitizeEmailHeader(from)
-	fromName = sanitizeEmailHeader(fromName)
-	subject = sanitizeEmailHeader(subject)
-	recipient := sanitizeEmailHeader(recipientEmail)
-
-	htmlBody := markdownToHTML(mdContent)
-	plainBody := mdContent
-
-	outerBoundary := "==AeternaFarewellMixed=="
-	altBoundary := "==AeternaFarewellAlt=="
-
-	var buf bytes.Buffer
-
-	buf.WriteString(fmt.Sprintf("From: %s <%s>\r\n", fromName, from))
-	buf.WriteString(fmt.Sprintf("To: %s\r\n", recipient))
-	buf.WriteString(fmt.Sprintf("Subject: %s\r\n", subject))
-	buf.WriteString("MIME-Version: 1.0\r\n")
-
-	if len(attachments) > 0 {
-		// multipart/mixed wrapping multipart/alternative + attachments
-		buf.WriteString(fmt.Sprintf("Content-Type: multipart/mixed; boundary=\"%s\"\r\n\r\n", outerBoundary))
-
-		buf.WriteString(fmt.Sprintf("--%s\r\n", outerBoundary))
-		buf.WriteString(fmt.Sprintf("Content-Type: multipart/alternative; boundary=\"%s\"\r\n\r\n", altBoundary))
-
-		writeAlternativeParts(&buf, altBoundary, plainBody, htmlBody)
-
-		buf.WriteString(fmt.Sprintf("--%s--\r\n", altBoundary))
-		buf.WriteString("\r\n")
-
-		for _, att := range attachments {
-			buf.WriteString(fmt.Sprintf("--%s\r\n", outerBoundary))
-			buf.WriteString(fmt.Sprintf("Content-Type: %s; name=\"%s\"\r\n", att.MimeType, mime.QEncoding.Encode("utf-8", att.Filename)))
-			buf.WriteString("Content-Transfer-Encoding: base64\r\n")
-			buf.WriteString(fmt.Sprintf("Content-Disposition: attachment; filename=\"%s\"\r\n\r\n", mime.QEncoding.Encode("utf-8", att.Filename)))
-			encoded := base64.StdEncoding.EncodeToString(att.Data)
-			for i := 0; i < len(encoded); i += 76 {
-				end := i + 76
-				if end > len(encoded) {
-					end = len(encoded)
-				}
-				buf.WriteString(encoded[i:end])
-				buf.WriteString("\r\n")
-			}
-		}
-		buf.WriteString(fmt.Sprintf("--%s--\r\n", outerBoundary))
-	} else {
-		// multipart/alternative only
-		buf.WriteString(fmt.Sprintf("Content-Type: multipart/alternative; boundary=\"%s\"\r\n\r\n", altBoundary))
-		writeAlternativeParts(&buf, altBoundary, plainBody, htmlBody)
-		buf.WriteString(fmt.Sprintf("--%s--\r\n", altBoundary))
-	}
-
-	message := buf.Bytes()
-	return s.sendRaw(settings, from, []string{recipient}, message)
-}
-
-func writeAlternativeParts(buf *bytes.Buffer, boundary, plainBody, htmlBody string) {
-	buf.WriteString(fmt.Sprintf("--%s\r\n", boundary))
-	buf.WriteString("Content-Type: text/plain; charset=UTF-8\r\n")
-	buf.WriteString("Content-Transfer-Encoding: 7bit\r\n\r\n")
-	buf.WriteString(plainBody)
-	buf.WriteString("\r\n")
-
-	buf.WriteString(fmt.Sprintf("--%s\r\n", boundary))
-	buf.WriteString("Content-Type: text/html; charset=UTF-8\r\n")
-	buf.WriteString("Content-Transfer-Encoding: 7bit\r\n\r\n")
-	buf.WriteString(htmlBody)
-	buf.WriteString("\r\n")
 }
 
 // emailLoginAuth implements LOGIN authentication mechanism

--- a/backend/internal/services/email_service_sanitize_test.go
+++ b/backend/internal/services/email_service_sanitize_test.go
@@ -1,0 +1,42 @@
+package services
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMarkdownToHTML_StripsRawHTML(t *testing.T) {
+	input := "Hello <img src=x onerror=alert(1)> <script>alert('x')</script> world"
+	out := markdownToHTML(input)
+
+	if strings.Contains(out, "<img") {
+		t.Fatalf("expected raw img tag to be stripped, got: %s", out)
+	}
+	if strings.Contains(out, "<script") {
+		t.Fatalf("expected raw script tag to be stripped, got: %s", out)
+	}
+	if strings.Contains(strings.ToLower(out), "onerror") {
+		t.Fatalf("expected inline handlers to be stripped, got: %s", out)
+	}
+}
+
+func TestMarkdownToHTML_BlocksUnsafeLinks(t *testing.T) {
+	input := "[click](javascript:alert(1))"
+	out := markdownToHTML(input)
+
+	if strings.Contains(strings.ToLower(out), "javascript:") {
+		t.Fatalf("expected javascript scheme to be blocked, got: %s", out)
+	}
+}
+
+func TestMarkdownToHTML_AllowsSafeLinkWithRelProtection(t *testing.T) {
+	input := "[site](https://example.com)"
+	out := markdownToHTML(input)
+
+	if !strings.Contains(out, "https://example.com") {
+		t.Fatalf("expected https link to be preserved, got: %s", out)
+	}
+	if !strings.Contains(out, "noopener") || !strings.Contains(out, "noreferrer") || !strings.Contains(out, "nofollow") {
+		t.Fatalf("expected rel protection attributes, got: %s", out)
+	}
+}

--- a/backend/internal/services/farewell_content_derivation.go
+++ b/backend/internal/services/farewell_content_derivation.go
@@ -1,0 +1,59 @@
+package services
+
+import (
+	"html"
+	"regexp"
+	"strings"
+)
+
+var htmlTagPattern = regexp.MustCompile(`<[^>]+>`)
+var markdownRawHTMLPattern = regexp.MustCompile(`(?is)<\/?[a-z][a-z0-9-]*(\s[^>]*)?>`)
+var markdownUnsafeLinkPattern = regexp.MustCompile(`(?i)\]\(\s*(javascript|vbscript|data):`)
+
+var htmlToTextNormalizer = strings.NewReplacer(
+	"</p>", " ",
+	"<br>", " ",
+	"<br/>", " ",
+	"<br />", " ",
+	"</li>", " ",
+	"</h1>", " ",
+	"</h2>", " ",
+	"</h3>", " ",
+	"</h4>", " ",
+	"</h5>", " ",
+	"</h6>", " ",
+	"</blockquote>", " ",
+	"</pre>", " ",
+	"</code>", " ",
+)
+
+// sanitizeFarewellMarkdown removes inline raw HTML and neutralizes unsafe link schemes.
+// HTML sanitization is still enforced again at render time.
+func sanitizeFarewellMarkdown(md string) string {
+	withoutRawHTML := markdownRawHTMLPattern.ReplaceAllString(md, "")
+	return markdownUnsafeLinkPattern.ReplaceAllString(withoutRawHTML, "](#")
+}
+
+func markdownToPlainText(md string) string {
+	if strings.TrimSpace(md) == "" {
+		return ""
+	}
+
+	rendered := markdownToHTML(md)
+	return htmlToPlainText(rendered)
+}
+
+func htmlToPlainText(rendered string) string {
+	if strings.TrimSpace(rendered) == "" {
+		return ""
+	}
+
+	rendered = htmlToTextNormalizer.Replace(rendered)
+	withoutTags := htmlTagPattern.ReplaceAllString(rendered, " ")
+	decoded := html.UnescapeString(withoutTags)
+	return strings.Join(strings.Fields(decoded), " ")
+}
+
+func countWordsFromMarkdown(md string) int {
+	return len(strings.Fields(markdownToPlainText(md)))
+}

--- a/backend/internal/services/farewell_content_derivation_test.go
+++ b/backend/internal/services/farewell_content_derivation_test.go
@@ -1,0 +1,39 @@
+package services
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitizeFarewellMarkdown_RemovesRawHTMLAndUnsafeLinks(t *testing.T) {
+	input := "Hi <script>alert('x')</script> [link](javascript:alert(1))"
+	out := sanitizeFarewellMarkdown(input)
+
+	if strings.Contains(strings.ToLower(out), "<script") {
+		t.Fatalf("expected raw html to be removed, got: %s", out)
+	}
+	if strings.Contains(strings.ToLower(out), "javascript:") {
+		t.Fatalf("expected javascript scheme to be removed, got: %s", out)
+	}
+}
+
+func TestSanitizeFarewellMarkdown_PreservesAutolinks(t *testing.T) {
+	input := "Read <https://example.com> and <mailto:test@example.com>"
+	out := sanitizeFarewellMarkdown(input)
+
+	if !strings.Contains(out, "<https://example.com>") {
+		t.Fatalf("expected https autolink to be preserved, got: %s", out)
+	}
+	if !strings.Contains(out, "<mailto:test@example.com>") {
+		t.Fatalf("expected mailto autolink to be preserved, got: %s", out)
+	}
+}
+
+func TestCountWordsFromMarkdown_UsesVisibleText(t *testing.T) {
+	input := "# Title\n\n- first item\n- second item\n\nVisit [Aeterna](https://aeterna.example)"
+	got := countWordsFromMarkdown(input)
+
+	if got != 7 {
+		t.Fatalf("expected 7 words, got %d", got)
+	}
+}

--- a/backend/internal/services/farewell_derivation_service.go
+++ b/backend/internal/services/farewell_derivation_service.go
@@ -1,0 +1,103 @@
+package services
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/alpyxn/aeterna/backend/internal/database"
+	"github.com/alpyxn/aeterna/backend/internal/models"
+	"github.com/alpyxn/aeterna/backend/internal/ports"
+)
+
+const defaultFarewellDerivationBatchSize = 50
+
+type FarewellDerivationService struct {
+	crypto CryptoService
+}
+
+func NewFarewellDerivationService() ports.FarewellDerivationPort {
+	return &FarewellDerivationService{crypto: CryptoService{}}
+}
+
+func (s *FarewellDerivationService) ProcessPending(batchSize int) (int, error) {
+	if batchSize <= 0 {
+		batchSize = defaultFarewellDerivationBatchSize
+	}
+
+	letters := make([]models.FarewellLetter, 0, batchSize)
+	err := database.DB.
+		Where("derivatives_pending = ?", true).
+		Where("deleted_at IS NULL").
+		Order("updated_at ASC").
+		Limit(batchSize).
+		Find(&letters).Error
+	if err != nil {
+		return 0, fmt.Errorf("failed to load pending farewell derivations: %w", err)
+	}
+
+	processed := 0
+	for _, letter := range letters {
+		if letter.UserID == "" {
+			continue
+		}
+		if err := s.deriveLetter(letter); err != nil {
+			slog.Error("Failed to process farewell derivation", "letter_id", letter.ID, "error", err)
+			continue
+		}
+		processed++
+	}
+
+	return processed, nil
+}
+
+func (s *FarewellDerivationService) deriveLetter(letter models.FarewellLetter) error {
+	contentCipher := letter.RawContent
+	if strings.TrimSpace(contentCipher) == "" {
+		contentCipher = letter.Content
+	}
+	if strings.TrimSpace(contentCipher) == "" {
+		return nil
+	}
+
+	rawMarkdown, err := s.crypto.Decrypt(contentCipher)
+	if err != nil {
+		return fmt.Errorf("failed to decrypt raw content: %w", err)
+	}
+
+	safeMarkdown := sanitizeFarewellMarkdown(rawMarkdown)
+	renderedHTML := markdownToHTML(safeMarkdown)
+	wordCount := countWordsFromMarkdown(safeMarkdown)
+
+	encryptedSafe, err := s.crypto.Encrypt(safeMarkdown)
+	if err != nil {
+		return fmt.Errorf("failed to encrypt sanitized content: %w", err)
+	}
+
+	encryptedRaw, err := s.crypto.Encrypt(rawMarkdown)
+	if err != nil {
+		return fmt.Errorf("failed to encrypt raw content: %w", err)
+	}
+
+	encryptedHTML, err := s.crypto.Encrypt(renderedHTML)
+	if err != nil {
+		return fmt.Errorf("failed to encrypt rendered html: %w", err)
+	}
+
+	updates := map[string]any{
+		"encrypted_content":       encryptedSafe,
+		"encrypted_content_raw":   encryptedRaw,
+		"encrypted_rendered_html": encryptedHTML,
+		"word_count":              wordCount,
+		"derivatives_pending":     false,
+	}
+
+	if err := database.ForTenant(letter.UserID).
+		Model(&models.FarewellLetter{}).
+		Where("id = ?", letter.ID).
+		Updates(updates).Error; err != nil {
+		return fmt.Errorf("failed to persist derived fields: %w", err)
+	}
+
+	return nil
+}

--- a/backend/internal/services/farewell_derivation_service_test.go
+++ b/backend/internal/services/farewell_derivation_service_test.go
@@ -1,0 +1,66 @@
+package services
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alpyxn/aeterna/backend/internal/models"
+)
+
+func TestFarewellDerivationService_ProcessPending_DerivesAndClearsPending(t *testing.T) {
+	db := setupTestDB(t)
+	initTestKeyManager(t)
+
+	msg := models.Message{
+		ID:              "m-derive",
+		UserID:          "u-derive",
+		Content:         "encrypted",
+		KeyFragment:     "v1",
+		ManagementToken: "tok",
+		RecipientEmail:  "owner@example.com",
+		TriggerDuration: 60,
+		LastSeen:        time.Now(),
+		Status:          models.StatusActive,
+	}
+	if err := db.Create(&msg).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	svc := FarewellService{}
+	created, err := svc.Create(
+		msg.UserID,
+		msg.ID,
+		"recipient@example.com",
+		"Subject",
+		"# Title\n\nRead <https://example.com> and [site](javascript:alert(1))",
+		10,
+	)
+	if err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+
+	derivation := NewFarewellDerivationService()
+	processed, err := derivation.ProcessPending(10)
+	if err != nil {
+		t.Fatalf("process pending failed: %v", err)
+	}
+	if processed < 1 {
+		t.Fatalf("expected at least one processed letter, got %d", processed)
+	}
+
+	var stored models.FarewellLetter
+	if err := db.First(&stored, "id = ?", created.ID).Error; err != nil {
+		t.Fatalf("failed to load stored letter: %v", err)
+	}
+
+	if stored.DerivativesPending {
+		t.Fatal("expected derivatives_pending=false after derivation")
+	}
+	if stored.WordCount == 0 {
+		t.Fatal("expected non-zero word_count after derivation")
+	}
+	if strings.TrimSpace(stored.RenderedHTML) == "" {
+		t.Fatal("expected encrypted rendered HTML to be persisted")
+	}
+}

--- a/backend/internal/services/farewell_service.go
+++ b/backend/internal/services/farewell_service.go
@@ -40,26 +40,37 @@ func (s FarewellService) Create(userID, messageID, recipientEmail, subject, cont
 		return models.FarewellLetter{}, BadRequest("Delay must be zero or positive", nil)
 	}
 
-	encrypted, err := farewellCrypto.Encrypt(content)
+	safeMarkdown := sanitizeFarewellMarkdown(content)
+
+	encryptedSafe, err := farewellCrypto.Encrypt(safeMarkdown)
+	if err != nil {
+		return models.FarewellLetter{}, err
+	}
+
+	encryptedRaw, err := farewellCrypto.Encrypt(content)
 	if err != nil {
 		return models.FarewellLetter{}, err
 	}
 
 	letter := models.FarewellLetter{
-		UserID:         userID,
-		MessageID:      messageID,
-		RecipientEmail: recipientEmail,
-		Subject:        subject,
-		Content:        encrypted,
-		DelayMinutes:   delayMinutes,
-		Status:         models.FarewellStatusPending,
+		UserID:             userID,
+		MessageID:          messageID,
+		RecipientEmail:     recipientEmail,
+		Subject:            subject,
+		Content:            encryptedSafe,
+		RawContent:         encryptedRaw,
+		RenderedHTML:       "",
+		WordCount:          0,
+		DerivativesPending: true,
+		DelayMinutes:       delayMinutes,
+		Status:             models.FarewellStatusPending,
 	}
 
 	if err := database.ForTenant(userID).Create(&letter).Error; err != nil {
 		return models.FarewellLetter{}, Internal("Failed to create farewell letter", err)
 	}
 
-	letter.Content = content
+	letter.Content = safeMarkdown
 	return letter, nil
 }
 
@@ -68,7 +79,7 @@ func (s FarewellService) List(userID, messageID string) ([]models.FarewellLetter
 		return nil, err
 	}
 
-	var letters []models.FarewellLetter
+	letters := make([]models.FarewellLetter, 0)
 	if err := database.ForTenant(userID).Where("message_id = ?", messageID).Order("created_at ASC").Find(&letters).Error; err != nil {
 		return nil, Internal("Failed to fetch farewell letters", err)
 	}
@@ -120,21 +131,32 @@ func (s FarewellService) Update(userID, messageID, id, recipientEmail, subject, 
 		return models.FarewellLetter{}, BadRequest("Delay must be zero or positive", nil)
 	}
 
-	encrypted, err := farewellCrypto.Encrypt(content)
+	safeMarkdown := sanitizeFarewellMarkdown(content)
+
+	encryptedSafe, err := farewellCrypto.Encrypt(safeMarkdown)
+	if err != nil {
+		return models.FarewellLetter{}, err
+	}
+
+	encryptedRaw, err := farewellCrypto.Encrypt(content)
 	if err != nil {
 		return models.FarewellLetter{}, err
 	}
 
 	letter.RecipientEmail = recipientEmail
 	letter.Subject = subject
-	letter.Content = encrypted
+	letter.Content = encryptedSafe
+	letter.RawContent = encryptedRaw
+	letter.RenderedHTML = ""
+	letter.WordCount = 0
+	letter.DerivativesPending = true
 	letter.DelayMinutes = delayMinutes
 
 	if err := database.ForTenant(userID).Save(&letter).Error; err != nil {
 		return models.FarewellLetter{}, Internal("Failed to update farewell letter", err)
 	}
 
-	letter.Content = content
+	letter.Content = safeMarkdown
 	return letter, nil
 }
 

--- a/backend/internal/services/farewell_service_test.go
+++ b/backend/internal/services/farewell_service_test.go
@@ -53,7 +53,7 @@ func TestFarewellCreate_PersistsZeroDelay(t *testing.T) {
 		msg.ID,
 		"recipient@example.com",
 		"Subject",
-		"Content",
+		"hello from aeterna",
 		0,
 	)
 	if err != nil {
@@ -63,6 +63,12 @@ func TestFarewellCreate_PersistsZeroDelay(t *testing.T) {
 	if letter.DelayMinutes != 0 {
 		t.Fatalf("expected returned delay 0, got %d", letter.DelayMinutes)
 	}
+	if letter.WordCount != 0 {
+		t.Fatalf("expected returned word_count 0 before background derivation, got %d", letter.WordCount)
+	}
+	if !letter.DerivativesPending {
+		t.Fatalf("expected derivatives_pending=true after create")
+	}
 
 	var stored models.FarewellLetter
 	if err := db.First(&stored, "id = ?", letter.ID).Error; err != nil {
@@ -70,6 +76,12 @@ func TestFarewellCreate_PersistsZeroDelay(t *testing.T) {
 	}
 	if stored.DelayMinutes != 0 {
 		t.Fatalf("expected stored delay 0, got %d", stored.DelayMinutes)
+	}
+	if stored.WordCount != 0 {
+		t.Fatalf("expected stored word_count 0 before background derivation, got %d", stored.WordCount)
+	}
+	if !stored.DerivativesPending {
+		t.Fatalf("expected stored derivatives_pending=true after create")
 	}
 }
 
@@ -100,6 +112,69 @@ func TestFarewellCreate_RejectsTriggeredMessage(t *testing.T) {
 	)
 	if err == nil || !strings.Contains(err.Error(), "Cannot add farewell letters after the switch has triggered") {
 		t.Fatalf("expected triggered create rejection, got %v", err)
+	}
+}
+
+func TestFarewellUpdate_MarksDerivativesPending(t *testing.T) {
+	db := setupTestDB(t)
+	initTestKeyManager(t)
+
+	msg := models.Message{
+		ID:              "m-word-count",
+		UserID:          "u-word-count",
+		Content:         "encrypted",
+		KeyFragment:     "v1",
+		ManagementToken: "tok",
+		RecipientEmail:  "owner@example.com",
+		TriggerDuration: 60,
+		LastSeen:        time.Now(),
+		Status:          models.StatusActive,
+	}
+	if err := db.Create(&msg).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := (FarewellService{}).Create(
+		msg.UserID,
+		msg.ID,
+		"recipient@example.com",
+		"Subject",
+		"one two",
+		0,
+	)
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	updated, err := (FarewellService{}).Update(
+		msg.UserID,
+		msg.ID,
+		created.ID,
+		"recipient@example.com",
+		"Updated subject",
+		"one two three four five",
+		10,
+	)
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	if updated.WordCount != 0 {
+		t.Fatalf("expected returned word_count 0 before background derivation, got %d", updated.WordCount)
+	}
+	if !updated.DerivativesPending {
+		t.Fatalf("expected derivatives_pending=true after update")
+	}
+
+	var stored models.FarewellLetter
+	if err := db.First(&stored, "id = ?", created.ID).Error; err != nil {
+		t.Fatalf("failed to load stored farewell letter: %v", err)
+	}
+	if stored.WordCount != 0 {
+		t.Fatalf("expected stored word_count 0 before background derivation, got %d", stored.WordCount)
+	}
+	if !stored.DerivativesPending {
+		t.Fatalf("expected stored derivatives_pending=true after update")
 	}
 }
 
@@ -251,6 +326,64 @@ func TestFarewellCancelPending_RemovesOnlyPendingLetters(t *testing.T) {
 	db.Model(&models.FarewellLetter{}).Where("message_id = ? AND status = ?", msg.ID, models.FarewellStatusSent).Count(&sentCount)
 	if sentCount != 1 {
 		t.Fatalf("expected sent letter to remain, got %d", sentCount)
+	}
+}
+
+func TestFarewellCreate_SanitizesStoredContentAndPreservesRaw(t *testing.T) {
+	db := setupTestDB(t)
+	initTestKeyManager(t)
+
+	msg := models.Message{
+		ID:              "m-markdown-word-count",
+		UserID:          "u-markdown-word-count",
+		Content:         "encrypted",
+		KeyFragment:     "v1",
+		ManagementToken: "tok",
+		RecipientEmail:  "owner@example.com",
+		TriggerDuration: 60,
+		LastSeen:        time.Now(),
+		Status:          models.StatusActive,
+	}
+	if err := db.Create(&msg).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	content := "# Title\n\n<script>alert('x')</script>\n\nVisit [Aeterna](javascript:alert(1))"
+	letter, err := (FarewellService{}).Create(
+		msg.UserID,
+		msg.ID,
+		"recipient@example.com",
+		"Subject",
+		content,
+		0,
+	)
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	if letter.WordCount != 0 {
+		t.Fatalf("expected returned word_count 0 before background derivation, got %d", letter.WordCount)
+	}
+	if strings.Contains(strings.ToLower(letter.Content), "<script") {
+		t.Fatalf("expected sanitized content without raw html, got: %s", letter.Content)
+	}
+	if strings.Contains(strings.ToLower(letter.Content), "javascript:") {
+		t.Fatalf("expected sanitized content without javascript links, got: %s", letter.Content)
+	}
+
+	var stored models.FarewellLetter
+	if err := db.First(&stored, "id = ?", letter.ID).Error; err != nil {
+		t.Fatalf("failed to load stored farewell letter: %v", err)
+	}
+	if strings.TrimSpace(stored.RawContent) == "" {
+		t.Fatal("expected raw encrypted content to be persisted")
+	}
+	rawDecrypted, err := (CryptoService{}).Decrypt(stored.RawContent)
+	if err != nil {
+		t.Fatalf("failed to decrypt raw content: %v", err)
+	}
+	if rawDecrypted != content {
+		t.Fatalf("expected raw content to match input, got %q", rawDecrypted)
 	}
 }
 

--- a/backend/internal/services/file_service.go
+++ b/backend/internal/services/file_service.go
@@ -178,7 +178,7 @@ func (s FileService) GetDecrypted(userID, attachmentID string) (filename, mimeTy
 
 // ListByMessageID returns all attachments for a message within a tenant
 func (s FileService) ListByMessageID(userID, messageID string) ([]models.Attachment, error) {
-	var attachments []models.Attachment
+	attachments := make([]models.Attachment, 0)
 	if err := database.ForTenant(userID).Where("message_id = ?", messageID).Order("created_at ASC").Find(&attachments).Error; err != nil {
 		return nil, Internal("Failed to fetch attachments", err)
 	}
@@ -265,7 +265,7 @@ func (s FileService) UploadFarewellAttachment(userID, letterID, filename, mimeTy
 
 // ListFarewellAttachmentsByLetterID returns all attachments for a farewell letter.
 func (s FileService) ListFarewellAttachmentsByLetterID(userID, letterID string) ([]models.FarewellAttachment, error) {
-	var attachments []models.FarewellAttachment
+	attachments := make([]models.FarewellAttachment, 0)
 	if err := database.ForTenant(userID).Where("letter_id = ?", letterID).Order("created_at ASC").Find(&attachments).Error; err != nil {
 		return nil, Internal("Failed to fetch farewell attachments", err)
 	}

--- a/backend/internal/services/message_service.go
+++ b/backend/internal/services/message_service.go
@@ -29,6 +29,32 @@ type farewellCountRow struct {
 	PendingFarewells int64
 }
 
+func enrichMessageSchedule(msg *models.Message) {
+	if msg == nil {
+		return
+	}
+
+	triggerAt := msg.LastSeen.UTC().Add(time.Duration(msg.TriggerDuration) * time.Minute)
+	triggerAtUTC := triggerAt.UTC()
+	msg.NextTriggerAt = &triggerAtUTC
+	msg.NextReminderAt = nil
+
+	if msg.Status != models.StatusActive {
+		return
+	}
+
+	for _, reminder := range msg.Reminders {
+		if reminder.Sent {
+			continue
+		}
+		candidate := triggerAt.Add(-time.Duration(reminder.MinutesBefore) * time.Minute).UTC()
+		if msg.NextReminderAt == nil || candidate.Before(*msg.NextReminderAt) {
+			candidateUTC := candidate
+			msg.NextReminderAt = &candidateUTC
+		}
+	}
+}
+
 func (s MessageService) Create(userID string, content string, recipientEmails []string, triggerDuration int, reminders []int) (models.Message, error) {
 	settings, err := msgSettingsService.Get(userID)
 	if err != nil {
@@ -79,7 +105,7 @@ func (s MessageService) Create(userID string, content string, recipientEmails []
 		KeyFragment:     "v1",
 		RecipientEmail:  normalizedRecipients,
 		TriggerDuration: triggerDuration,
-		LastSeen:        time.Now(),
+		LastSeen:        time.Now().UTC(),
 		Status:          models.StatusActive,
 	}
 
@@ -107,6 +133,7 @@ func (s MessageService) Create(userID string, content string, recipientEmails []
 	}
 
 	msg.Content = content
+	enrichMessageSchedule(&msg)
 	return msg, nil
 }
 
@@ -147,6 +174,7 @@ func (s MessageService) GetByID(userID, id string) (models.Message, error) {
 
 	count, _ := msgFileService.CountByMessageID(userID, id)
 	msg.AttachmentCount = count
+	enrichMessageSchedule(&msg)
 
 	return msg, nil
 }
@@ -205,6 +233,7 @@ func (s MessageService) List(userID string) ([]models.Message, error) {
 			messages[i].FarewellCount = fc.Total
 			messages[i].PendingFarewells = fc.PendingFarewells
 		}
+		enrichMessageSchedule(&messages[i])
 	}
 
 	return messages, nil
@@ -223,10 +252,11 @@ func (s MessageService) Heartbeat(userID, id string) (models.Message, error) {
 		return models.Message{}, BadRequest("Cannot send heartbeat to a triggered message. The message has already been delivered.", nil)
 	}
 
-	msg.LastSeen = time.Now()
+	msg.LastSeen = time.Now().UTC()
 	if err := database.ForTenant(userID).Save(&msg).Error; err != nil {
 		return models.Message{}, Internal("Failed to update heartbeat", err)
 	}
+	enrichMessageSchedule(&msg)
 
 	return msg, nil
 }
@@ -320,7 +350,7 @@ func (s MessageService) Update(userID, id, content string, recipientEmails []str
 
 	msg.Content = encrypted
 	msg.TriggerDuration = triggerDuration
-	msg.LastSeen = time.Now()
+	msg.LastSeen = time.Now().UTC()
 	err = database.DB.Transaction(func(tx *gorm.DB) error {
 		if err := database.TenantTx(tx, userID).Save(&msg).Error; err != nil {
 			return Internal("Failed to update message", err)
@@ -351,5 +381,6 @@ func (s MessageService) Update(userID, id, content string, recipientEmails []str
 	}
 
 	msg.Content = content
+	enrichMessageSchedule(&msg)
 	return msg, nil
 }

--- a/backend/internal/services/message_service_delete_test.go
+++ b/backend/internal/services/message_service_delete_test.go
@@ -57,6 +57,7 @@ func TestMessageDelete_NoFarewellNoAttachments(t *testing.T) {
 func TestMessageList_IncludesFarewellCounts(t *testing.T) {
 	db := setupTestDB(t)
 	initTestKeyManager(t)
+	lastSeen := time.Date(2024, 1, 10, 12, 0, 0, 0, time.UTC)
 	encrypted, err := (CryptoService{}).Encrypt("hello")
 	if err != nil {
 		t.Fatal(err)
@@ -64,7 +65,7 @@ func TestMessageList_IncludesFarewellCounts(t *testing.T) {
 	if err := db.Create(&models.Message{
 		ID: "m-counts", UserID: "u-counts", Content: encrypted, KeyFragment: "v1",
 		ManagementToken: "tok", RecipientEmail: "a@a.com",
-		TriggerDuration: 60, LastSeen: time.Now(), Status: models.StatusTriggered,
+		TriggerDuration: 60, LastSeen: lastSeen, Status: models.StatusTriggered,
 	}).Error; err != nil {
 		t.Fatal(err)
 	}
@@ -107,6 +108,65 @@ func TestMessageList_IncludesFarewellCounts(t *testing.T) {
 	}
 	if messages[0].PendingFarewells != 1 {
 		t.Fatalf("expected pending_farewells=1, got %d", messages[0].PendingFarewells)
+	}
+	if messages[0].NextTriggerAt == nil {
+		t.Fatal("expected next_trigger_at to be populated")
+	}
+	expectedTrigger := lastSeen.Add(60 * time.Minute)
+	if !messages[0].NextTriggerAt.Equal(expectedTrigger) {
+		t.Fatalf("expected next_trigger_at=%s, got %s", expectedTrigger.Format(time.RFC3339), messages[0].NextTriggerAt.Format(time.RFC3339))
+	}
+	if messages[0].NextReminderAt != nil {
+		t.Fatalf("expected next_reminder_at to be nil for triggered message, got %s", messages[0].NextReminderAt.Format(time.RFC3339))
+	}
+}
+
+func TestMessageList_ComputesNextReminderAtForPendingReminders(t *testing.T) {
+	db := setupTestDB(t)
+	initTestKeyManager(t)
+	lastSeen := time.Date(2024, 2, 15, 9, 30, 0, 0, time.UTC)
+	encrypted, err := (CryptoService{}).Encrypt("hello")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&models.Message{
+		ID: "m-reminder", UserID: "u-reminder", Content: encrypted, KeyFragment: "v1",
+		ManagementToken: "tok", RecipientEmail: "a@a.com",
+		TriggerDuration: 180, LastSeen: lastSeen, Status: models.StatusActive,
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+	for _, reminder := range []models.MessageReminder{
+		{MessageID: "m-reminder", MinutesBefore: 30, Sent: false},
+		{MessageID: "m-reminder", MinutesBefore: 120, Sent: false},
+		{MessageID: "m-reminder", MinutesBefore: 5, Sent: true},
+	} {
+		if err := db.Create(&reminder).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	messages, err := (MessageService{}).List("u-reminder")
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(messages))
+	}
+	msg := messages[0]
+	if msg.NextTriggerAt == nil {
+		t.Fatal("expected next_trigger_at to be populated")
+	}
+	expectedTrigger := lastSeen.Add(180 * time.Minute)
+	if !msg.NextTriggerAt.Equal(expectedTrigger) {
+		t.Fatalf("expected next_trigger_at=%s, got %s", expectedTrigger.Format(time.RFC3339), msg.NextTriggerAt.Format(time.RFC3339))
+	}
+	if msg.NextReminderAt == nil {
+		t.Fatal("expected next_reminder_at to be populated")
+	}
+	expectedReminder := expectedTrigger.Add(-120 * time.Minute)
+	if !msg.NextReminderAt.Equal(expectedReminder) {
+		t.Fatalf("expected next_reminder_at=%s, got %s", expectedReminder.Format(time.RFC3339), msg.NextReminderAt.Format(time.RFC3339))
 	}
 }
 

--- a/backend/internal/worker/worker.go
+++ b/backend/internal/worker/worker.go
@@ -15,25 +15,28 @@ import (
 
 // Worker runs the background goroutine that checks heartbeats, reminders, and farewell letters.
 type Worker struct {
-	settings ports.SettingsServicePort
-	webhooks ports.WebhookStorePort
-	files    ports.FileServicePort
-	email    services.EmailService
-	webhook  services.WebhookService
-	cfg      config.Config
+	settings           ports.SettingsServicePort
+	webhooks           ports.WebhookStorePort
+	files              ports.FileServicePort
+	farewellDerivation ports.FarewellDerivationPort
+	email              services.EmailService
+	webhook            services.WebhookService
+	cfg                config.Config
 }
 
 func New(
 	settings ports.SettingsServicePort,
 	webhooks ports.WebhookStorePort,
 	files ports.FileServicePort,
+	farewellDerivation ports.FarewellDerivationPort,
 	cfg config.Config,
 ) *Worker {
 	return &Worker{
-		settings: settings,
-		webhooks: webhooks,
-		files:    files,
-		cfg:      cfg,
+		settings:           settings,
+		webhooks:           webhooks,
+		files:              files,
+		farewellDerivation: farewellDerivation,
+		cfg:                cfg,
 	}
 }
 
@@ -42,9 +45,25 @@ func (w *Worker) Start() {
 	defer ticker.Stop()
 
 	for range ticker.C {
+		w.checkFarewellDerivatives()
 		w.checkReminders()
 		w.checkHeartbeats()
 		w.checkFarewellLetters()
+	}
+}
+
+func (w *Worker) checkFarewellDerivatives() {
+	if w.farewellDerivation == nil {
+		return
+	}
+
+	processed, err := w.farewellDerivation.ProcessPending(50)
+	if err != nil {
+		slog.Error("Error checking farewell derivatives", "error", err)
+		return
+	}
+	if processed > 0 {
+		slog.Info("Farewell derivatives processed", "count", processed)
 	}
 }
 
@@ -191,7 +210,7 @@ func (w *Worker) triggerSwitch(msg models.Message) {
 		}
 	}
 
-	now := time.Now()
+	now := time.Now().UTC()
 	msg.Status = models.StatusTriggered
 	msg.TriggeredAt = &now
 	if err := database.ForTenant(msg.UserID).Save(&msg).Error; err != nil {
@@ -270,10 +289,20 @@ func (w *Worker) sendFarewellLetter(letter models.FarewellLetter) {
 		return
 	}
 
-	decrypted, err := services.CryptoService{}.Decrypt(letter.Content)
+	decryptedSafeMarkdown, err := services.CryptoService{}.Decrypt(letter.Content)
 	if err != nil {
 		slog.Error("Failed to decrypt farewell letter content", "letter_id", letter.ID, "error", err)
 		return
+	}
+
+	var renderedHTML string
+	if strings.TrimSpace(letter.RenderedHTML) != "" {
+		decryptedHTML, htmlErr := services.CryptoService{}.Decrypt(letter.RenderedHTML)
+		if htmlErr != nil {
+			slog.Warn("Failed to decrypt pre-rendered farewell HTML, using markdown fallback", "letter_id", letter.ID, "error", htmlErr)
+		} else {
+			renderedHTML = decryptedHTML
+		}
 	}
 
 	rawAttachments, err := w.files.ListFarewellAttachmentsByLetterID(letter.UserID, letter.ID)
@@ -295,12 +324,19 @@ func (w *Worker) sendFarewellLetter(letter models.FarewellLetter) {
 		})
 	}
 
-	if err := w.email.SendFarewellLetter(settings, letter.RecipientEmail, letter.Subject, decrypted, emailAttachments); err != nil {
+	if err := w.email.SendFarewellLetterPreRendered(
+		settings,
+		letter.RecipientEmail,
+		letter.Subject,
+		decryptedSafeMarkdown,
+		renderedHTML,
+		emailAttachments,
+	); err != nil {
 		slog.Error("Failed to send farewell letter", "letter_id", letter.ID, "recipient", letter.RecipientEmail, "error", err)
 		return
 	}
 
-	now := time.Now()
+	now := time.Now().UTC()
 	if err := database.ForTenant(letter.UserID).Model(&letter).Updates(map[string]any{
 		"status":  models.FarewellStatusSent,
 		"sent_at": now,


### PR DESCRIPTION
## Summary

This change set introduces three backend capabilities:

1. Refresh-session support for v2 authentication.
2. Background farewell-content derivation (sanitized rendered HTML + word count).
3. Computed message scheduling fields for clients (`next_trigger_at`, `next_reminder_at`).

It also includes the required worker and bootstrap updates so these behaviors run end-to-end.

## Functional Changes

### 1) Auth refresh-session flow (v2)

- Added refresh-session persistence model (`RefreshSession`) with hashed token storage.
- Added refresh TTL configuration (`AUTH_REFRESH_TTL_HOURS`) and defaults.
- Added auth service operations for:
  - issuing access + refresh pair,
  - rotating refresh tokens,
  - revoking refresh tokens.
- Added `POST /api/v2/auth/refresh`.
- Updated v2 auth responses to include:
  - `refresh_token`
  - `refresh_expires_at`
- Added tests for refresh rotation, revocation, and concurrency behavior.

### 2) Farewell derivation pipeline

- Added derivation utilities to transform farewell markdown/content into:
  - sanitized rendered HTML,
  - word count metric.
- Added background derivation service to process pending farewells.
- Updated farewell model/service behavior to track and persist derivation state/outputs.
- Worker now executes derivation processing in its cycle.
- Added focused derivation and sanitization tests.

### 3) Message scheduling metadata

- Added computed message fields:
  - `next_trigger_at`
  - `next_reminder_at`
- Message service now enriches read responses with these values.
- Added tests covering schedule computation and reminder selection behavior.

## Technical Notes

- Bootstrap wiring in `main.go` ensures:
  - handler production flag configuration is set,
  - farewell derivation service is wired into worker startup.
- Worker timestamp handling uses UTC consistently in updated paths.

## Validation

Executed successfully:

- `go vet ./...`
- `go test ./...`
- `npm run lint`
- `npm run build`

Backend tests were run with local env overrides unset to avoid accidental environment coupling:

- `BASE_URL`
- `AUTH_SESSION_TTL_HOURS`
- `AUTH_REFRESH_TTL_HOURS`

Commit Message:

Implement v2 refresh-token session rotation and revocation with persisted hashed refresh sessions.
Add farewell content derivation pipeline (sanitized rendered HTML + word count) and wire processing through the worker cycle.
Expose computed message scheduling fields (next_trigger_at and next_reminder_at) in service responses with test coverage.
Include required bootstrap and middleware adjustments to keep runtime behavior and validation consistent.